### PR TITLE
Plugins are automatically copied over

### DIFF
--- a/Application/Retro_ML.Application.csproj
+++ b/Application/Retro_ML.Application.csproj
@@ -95,10 +95,8 @@
 		<Copy Condition="Exists('smw.sfc')" SourceFiles="@(ROM)" DestinationFolder="$(TargetDir)" />
 		<Message Text="Copied ROM to project root" Condition="Exists('$(TargetDir)\smw.sfc')" Importance="high" />
 	</Target>
-	<Target Name="BeforePlugins" AfterTargets="AfterCompile">
+	<Target Name="CopyPlugins" AfterTargets="AfterCompile">
 		<MakeDir Directories="$(TargetDir)plugins" />
-	</Target>
-	<Target Name="CopyPlugins" AfterTargets="BeforePlugins">
 		<Copy SourceFiles="%(Plugins.Identity)" DestinationFolder="$(TargetDir)plugins"/>
 		<Message Text="Copied: %(Plugins.Identity) to $(TargetDir)plugins\" Importance="high"/>
 	</Target>

--- a/Application/Retro_ML.Application.csproj
+++ b/Application/Retro_ML.Application.csproj
@@ -10,6 +10,8 @@
 	<ItemGroup>
 		<Emulator Include="..\Submodules\BizHawk\output\**\*.*" />
 		<ROM Include="smw.sfc" />
+		<Plugins Include="..\Games\*\$(OutDir)\Retro_ML.*.dll" />
+		<Plugins Include="..\Consoles\*\$(OutDir)\Retro_ML.*.dll" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -92,5 +94,12 @@
 
 		<Copy Condition="Exists('smw.sfc')" SourceFiles="@(ROM)" DestinationFolder="$(TargetDir)" />
 		<Message Text="Copied ROM to project root" Condition="Exists('$(TargetDir)\smw.sfc')" Importance="high" />
+	</Target>
+	<Target Name="BeforePlugins" AfterTargets="AfterCompile">
+		<MakeDir Directories="$(TargetDir)plugins" />
+	</Target>
+	<Target Name="CopyPlugins" AfterTargets="BeforePlugins">
+		<Copy SourceFiles="%(Plugins.Identity)" DestinationFolder="$(TargetDir)plugins"/>
+		<Message Text="Copied: %(Plugins.Identity) to $(TargetDir)plugins\" Importance="high"/>
 	</Target>
 </Project>

--- a/Application/Retro_ML.Application.csproj
+++ b/Application/Retro_ML.Application.csproj
@@ -10,8 +10,8 @@
 	<ItemGroup>
 		<Emulator Include="..\Submodules\BizHawk\output\**\*.*" />
 		<ROM Include="smw.sfc" />
-		<Plugins Include="..\Games\*\$(OutDir)\Retro_ML.*.dll" />
-		<Plugins Include="..\Consoles\*\$(OutDir)\Retro_ML.*.dll" />
+		<Plugins Include="..\Games\**\$(OutDir)\Retro_ML.*.dll" />
+		<Plugins Include="..\Consoles\**\$(OutDir)\Retro_ML.*.dll" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Retro-ML.sln
+++ b/Retro-ML.sln
@@ -4,6 +4,10 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.1.32104.313
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Retro_ML.Application", "Application\Retro_ML.Application.csproj", "{A58F9046-96B5-4E52-B173-2DDA9C821C1E}"
+	ProjectSection(ProjectDependencies) = postProject
+		{030FDB49-1AB0-4983-B287-5481AF3B464A} = {030FDB49-1AB0-4983-B287-5481AF3B464A}
+		{7735343C-8DCF-4061-B168-0CAA36AA4159} = {7735343C-8DCF-4061-B168-0CAA36AA4159}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Retro_ML_TEST", "Retro_ML_TEST\Retro_ML_TEST.csproj", "{04A5F47C-D2D0-48BC-88D7-A91B7FCF6450}"
 EndProject
@@ -12,6 +16,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Consoles", "Consoles", "{10512FB0-B56B-48D4-A9EB-3E70F5AC0AE6}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Retro_ML.SuperMarioWorld", "Games\SuperMarioWorld\Retro_ML.SuperMarioWorld.csproj", "{030FDB49-1AB0-4983-B287-5481AF3B464A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{7735343C-8DCF-4061-B168-0CAA36AA4159} = {7735343C-8DCF-4061-B168-0CAA36AA4159}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Retro_ML", "Retro_ML\Retro_ML.csproj", "{94DE3EBD-EED3-4B5F-A2DC-4EAB2AC8EBAF}"
 EndProject


### PR DESCRIPTION
Whenever the Application is built, all game and console plugins are and will be copied over to the ./plugins/ folder

The plugins are now built before the Application

Once this is merged, it will be important to make sure the Application has all the plugins as a __Solution__ dependency, or else, they might end up being built before the Application, which would cause headaches

![image](https://user-images.githubusercontent.com/29369803/167778658-75e95765-f37c-494b-85d0-707eb450118d.png)
![image](https://user-images.githubusercontent.com/29369803/167778724-d4b44749-a483-4285-9c0c-f543f72475c0.png)
