### PR TITLE
Fixed stupid bug when config.ini is missing from emu folder

### DIFF
--- a/Application/Retro_ML.Application.csproj
+++ b/Application/Retro_ML.Application.csproj
@@ -67,6 +67,10 @@
 	  <None Update="config\appConfig.json">
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>
+	  <None Update="emu\config.ini">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	    <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+	  </None>
 	  <None Update="lua\bizhawkAdapter.lua">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>

--- a/Application/emu/config.ini
+++ b/Application/emu/config.ini
@@ -1,0 +1,4642 @@
+﻿{
+  "PreferredCores": {
+    "NES": "QuickNes",
+    "SNES": "Snes9x",
+    "GB": "Gambatte",
+    "GBC": "Gambatte",
+    "GBL": "GambatteLink",
+    "SGB": "Gambatte",
+    "PCE": "TurboNyma",
+    "PCECD": "TurboNyma",
+    "SGX": "TurboNyma"
+  },
+  "PreferredPlatformsForExtensions": {
+    ".bin": "",
+    ".cue": "",
+    ".img": "",
+    ".iso": "",
+    ".rom": ""
+  },
+  "PathEntries": {
+    "Paths": [
+      {
+        "Type": "Base",
+        "Path": ".",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "Firmware",
+        "Path": "./Firmware",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "Movies",
+        "Path": "./Movies",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "Movie backups",
+        "Path": "./Movies/backup",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "A/V Dumps",
+        "Path": ".",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "Tools",
+        "Path": "./Tools",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "Lua",
+        "Path": "./Lua",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "Watch (.wch)",
+        "Path": "./.",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "Debug Logs",
+        "Path": ".",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "Macros",
+        "Path": "./Movies/Macros",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "TAStudio states",
+        "Path": "./Movies/TAStudio states",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "Multi-Disk Bundles",
+        "Path": ".",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "External Tools",
+        "Path": "./ExternalTools",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "Temp Files",
+        "Path": "",
+        "System": "Global_NULL"
+      },
+      {
+        "Type": "Base",
+        "Path": "./32X",
+        "System": "32X"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "32X"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "32X"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "32X"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "32X"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "32X"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Atari 2600",
+        "System": "A26"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "A26"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "A26"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "A26"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "A26"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Atari 7800",
+        "System": "A78"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "A78"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "A78"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "A78"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "A78"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "A78"
+      },
+      {
+        "Type": "Base",
+        "Path": "./AmstradCPC",
+        "System": "AmstradCPC"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "AmstradCPC"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "AmstradCPC"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "AmstradCPC"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "AmstradCPC"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Apple II",
+        "System": "AppleII"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "AppleII"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "AppleII"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "AppleII"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "AppleII"
+      },
+      {
+        "Type": "Base",
+        "Path": "./C64",
+        "System": "C64"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "C64"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "C64"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "C64"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "C64"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Channel F",
+        "System": "ChannelF"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "ChannelF"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "ChannelF"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "ChannelF"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "ChannelF"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Coleco",
+        "System": "Coleco"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "Coleco"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "Coleco"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "Coleco"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "Coleco"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Gameboy Link",
+        "System": "GBL"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "GBL"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "GBL"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "GBL"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "GBL"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "GBL"
+      },
+      {
+        "Type": "Palettes",
+        "Path": "./Palettes",
+        "System": "GBL"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Gameboy",
+        "System": "GB_GBC_SGB"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "GB_GBC_SGB"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "GB_GBC_SGB"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "GB_GBC_SGB"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "GB_GBC_SGB"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "GB_GBC_SGB"
+      },
+      {
+        "Type": "Palettes",
+        "Path": "./Palettes",
+        "System": "GB_GBC_SGB"
+      },
+      {
+        "Type": "Base",
+        "Path": "./GBA",
+        "System": "GBA"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "GBA"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "GBA"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "GBA"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "GBA"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "GBA"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Genesis",
+        "System": "GEN"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "GEN"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "GEN"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "GEN"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "GEN"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "GEN"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Game Gear",
+        "System": "GG"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "GG"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "GG"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "GG"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "GG"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "GG"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Dual Game Gear",
+        "System": "GGL"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "GGL"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "GGL"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "GGL"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "GGL"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "GGL"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Intellivision",
+        "System": "INTV"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "INTV"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "INTV"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "INTV"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "INTV"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "INTV"
+      },
+      {
+        "Type": "Palettes",
+        "Path": "./Palettes",
+        "System": "INTV"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Libretro",
+        "System": "Libretro"
+      },
+      {
+        "Type": "ROM",
+        "Path": "%recent%",
+        "System": "Libretro"
+      },
+      {
+        "Type": "Cores",
+        "Path": "./Cores",
+        "System": "Libretro"
+      },
+      {
+        "Type": "System",
+        "Path": "./System",
+        "System": "Libretro"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "Libretro"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "Libretro"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "Libretro"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "Libretro"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Lynx",
+        "System": "Lynx"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "Lynx"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "Lynx"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "Lynx"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "Lynx"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "Lynx"
+      },
+      {
+        "Type": "Base",
+        "Path": "./MSX",
+        "System": "MSX"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "MSX"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "MSX"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "MSX"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "MSX"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "MSX"
+      },
+      {
+        "Type": "Base",
+        "Path": "./N64",
+        "System": "N64"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "N64"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "N64"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "N64"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "N64"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "N64"
+      },
+      {
+        "Type": "Base",
+        "Path": "./NDS",
+        "System": "NDS"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "NDS"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "NDS"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "NDS"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "NDS"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "NDS"
+      },
+      {
+        "Type": "Base",
+        "Path": "./NES",
+        "System": "NES"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "NES"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "NES"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "NES"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "NES"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "NES"
+      },
+      {
+        "Type": "Palettes",
+        "Path": "./Palettes",
+        "System": "NES"
+      },
+      {
+        "Type": "Base",
+        "Path": "./NGP",
+        "System": "NGP"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "NGP"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "NGP"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "NGP"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "NGP"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "NGP"
+      },
+      {
+        "Type": "Base",
+        "Path": "./O2",
+        "System": "O2"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "O2"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "O2"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "O2"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "O2"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "O2"
+      },
+      {
+        "Type": "Base",
+        "Path": "./PC Engine",
+        "System": "PCE_PCECD_SGX"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "PCE_PCECD_SGX"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "PCE_PCECD_SGX"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "PCE_PCECD_SGX"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "PCE_PCECD_SGX"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "PCE_PCECD_SGX"
+      },
+      {
+        "Type": "Base",
+        "Path": "./PCFX",
+        "System": "PCFX"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "PCFX"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "PCFX"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "PCFX"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "PCFX"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "PCFX"
+      },
+      {
+        "Type": "Base",
+        "Path": "./PS2",
+        "System": "PS2"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "PS2"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "PS2"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "PS2"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "PS2"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "PS2"
+      },
+      {
+        "Type": "Base",
+        "Path": "./PSX",
+        "System": "PSX"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "PSX"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "PSX"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "PSX"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "PSX"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "PSX"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Saturn",
+        "System": "SAT"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "SAT"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "SAT"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "SAT"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "SAT"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "SAT"
+      },
+      {
+        "Type": "Base",
+        "Path": "./SG-1000",
+        "System": "SG"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "SG"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "SG"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "SG"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "SG"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "SG"
+      },
+      {
+        "Type": "Base",
+        "Path": "./SMS",
+        "System": "SMS"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "SMS"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "SMS"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "SMS"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "SMS"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "SMS"
+      },
+      {
+        "Type": "Base",
+        "Path": "./SNES",
+        "System": "SNES"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "SNES"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "SNES"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "SNES"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "SNES"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "SNES"
+      },
+      {
+        "Type": "Base",
+        "Path": "./TI83",
+        "System": "TI83"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "TI83"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "TI83"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "TI83"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "TI83"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "TI83"
+      },
+      {
+        "Type": "Base",
+        "Path": "./Uzebox",
+        "System": "UZE"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "UZE"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "UZE"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "UZE"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "UZE"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "UZE"
+      },
+      {
+        "Type": "Base",
+        "Path": "./VB",
+        "System": "VB"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "VB"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "VB"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "VB"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "VB"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "VB"
+      },
+      {
+        "Type": "Base",
+        "Path": "./VEC",
+        "System": "VEC"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "VEC"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "VEC"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "VEC"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "VEC"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "VEC"
+      },
+      {
+        "Type": "Base",
+        "Path": "./WonderSwan",
+        "System": "WSWAN"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "WSWAN"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "WSWAN"
+      },
+      {
+        "Type": "Save RAM",
+        "Path": "./SaveRAM",
+        "System": "WSWAN"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "WSWAN"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "WSWAN"
+      },
+      {
+        "Type": "Base",
+        "Path": "./ZXSpectrum",
+        "System": "ZXSpectrum"
+      },
+      {
+        "Type": "ROM",
+        "Path": ".",
+        "System": "ZXSpectrum"
+      },
+      {
+        "Type": "Savestates",
+        "Path": "./State",
+        "System": "ZXSpectrum"
+      },
+      {
+        "Type": "Screenshots",
+        "Path": "./Screenshots",
+        "System": "ZXSpectrum"
+      },
+      {
+        "Type": "Cheats",
+        "Path": "./Cheats",
+        "System": "ZXSpectrum"
+      }
+    ],
+    "UseRecentForRoms": false,
+    "LastRomPath": null
+  },
+  "FirmwareUserSpecifications": {},
+  "InputHotkeyOverrideOptions": 0,
+  "NoMixedInputHokeyOverride": false,
+  "StackOSDMessages": false,
+  "TargetZoomFactors": {
+    "NULL": 2,
+    "SNES": 3
+  },
+  "TargetScanlineFilterIntensity": 128,
+  "TargetDisplayFilter": 0,
+  "DispFinalFilter": 0,
+  "DispUserFilterPath": "",
+  "RecentRoms": {
+    "recentlist": [],
+    "MAX_RECENT_FILES": 10,
+    "AutoLoad": false,
+    "Frozen": false
+  },
+  "PauseWhenMenuActivated": true,
+  "SaveWindowPosition": true,
+  "StartPaused": false,
+  "StartFullscreen": false,
+  "MainWndx": 544,
+  "MainWndy": 262,
+  "RunInBackground": true,
+  "AcceptBackgroundInput": false,
+  "AcceptBackgroundInputControllerOnly": false,
+  "HandleAlternateKeyboardLayouts": false,
+  "SingleInstanceMode": false,
+  "AllowUdlr": false,
+  "ShowContextMenu": true,
+  "HotkeyConfigAutoTab": true,
+  "InputConfigAutoTab": true,
+  "SkipWaterboxIntegrityChecks": false,
+  "AutofireOn": 1,
+  "AutofireOff": 1,
+  "AutofireLagFrames": true,
+  "SaveSlot": 0,
+  "AutoLoadLastSaveSlot": false,
+  "SkipLagFrame": false,
+  "SuppressAskSave": false,
+  "AviCaptureOsd": false,
+  "AviCaptureLua": false,
+  "ScreenshotCaptureOsd": false,
+  "FirstBoot": true,
+  "UpdateAutoCheckEnabled": false,
+  "UpdateLastCheckTimeUtc": null,
+  "UpdateLatestVersion": "",
+  "UpdateIgnoreVersion": "",
+  "SkipOutdatedOsCheck": false,
+  "BackupSaveram": false,
+  "AutosaveSaveRAM": false,
+  "FlushSaveRamFrames": 0,
+  "LuaEngine": 0,
+  "TurboSeek": false,
+  "SelectedProfile": 0,
+  "N64UseCircularAnalogConstraint": true,
+  "FrameProgressDelayMs": 500,
+  "FrameSkip": 0,
+  "SpeedPercent": 100,
+  "SpeedPercentAlternate": 400,
+  "ClockThrottle": true,
+  "Unthrottled": false,
+  "AutoMinimizeSkipping": true,
+  "VSyncThrottle": false,
+  "Rewind": {
+    "UseCompression": false,
+    "UseDelta": false,
+    "Enabled": false,
+    "BufferSize": 512,
+    "UseFixedRewindInterval": false,
+    "TargetFrameLength": 600,
+    "TargetRewindInterval": 5,
+    "BackingStore": 0
+  },
+  "Savestates": {
+    "Type": 0,
+    "CompressionLevelNormal": 1,
+    "CompressionLevelRewind": 0,
+    "MakeBackups": true,
+    "SaveScreenshot": true,
+    "BigScreenshotSize": 131072,
+    "NoLowResLargeScreenshots": false
+  },
+  "Movies": {
+    "MovieEndAction": 3,
+    "EnableBackupMovies": true,
+    "MoviesOnDisk": false,
+    "MovieCompressionLevel": 2,
+    "VBAStyleMovieLoadState": false,
+    "DefaultTasStateManagerSettings": {
+      "CurrentUseCompression": false,
+      "CurrentBufferSize": 256,
+      "CurrentTargetFrameLength": 500,
+      "CurrentStoreType": 0,
+      "RecentUseCompression": false,
+      "RecentBufferSize": 128,
+      "RecentTargetFrameLength": 2000,
+      "RecentStoreType": 0,
+      "GapsUseCompression": false,
+      "GapsBufferSize": 64,
+      "GapsTargetFrameLength": 125,
+      "GapsStoreType": 0,
+      "AncientStateInterval": 5000,
+      "AncientStoreType": 0
+    }
+  },
+  "VSync": false,
+  "DispAlternateVsync": false,
+  "DisplayFps": true,
+  "DisplayFrameCounter": false,
+  "DisplayLagCounter": false,
+  "DisplayInput": true,
+  "DisplayRerecordCount": false,
+  "DisplayMessages": true,
+  "DispFixAspectRatio": true,
+  "DispFixScaleInteger": false,
+  "DispFullscreenHacks": false,
+  "DispAutoPrescale": false,
+  "DispSpeedupFeatures": 2,
+  "Fps": {
+    "X": 0,
+    "Y": 0,
+    "Anchor": 0
+  },
+  "FrameCounter": {
+    "X": 0,
+    "Y": 14,
+    "Anchor": 0
+  },
+  "LagCounter": {
+    "X": 0,
+    "Y": 42,
+    "Anchor": 0
+  },
+  "InputDisplay": {
+    "X": 0,
+    "Y": 60,
+    "Anchor": 0
+  },
+  "ReRecordCounter": {
+    "X": 0,
+    "Y": 56,
+    "Anchor": 0
+  },
+  "Messages": {
+    "X": 0,
+    "Y": 0,
+    "Anchor": 2
+  },
+  "Autohold": {
+    "X": 0,
+    "Y": 0,
+    "Anchor": 1
+  },
+  "RamWatches": {
+    "X": 0,
+    "Y": 70,
+    "Anchor": 0
+  },
+  "MessagesColor": -1,
+  "AlertMessageColor": -65536,
+  "LastInputColor": -23296,
+  "MovieInput": -8355712,
+  "DispPrescale": 1,
+  "DispMethod": 2,
+  "DispChromeFrameWindowed": 2,
+  "DispChromeStatusBarWindowed": true,
+  "DispChromeCaptionWindowed": true,
+  "DispChromeMenuWindowed": true,
+  "DispChromeStatusBarFullscreen": false,
+  "DispChromeMenuFullscreen": false,
+  "DispChromeFullscreenAutohideMouse": true,
+  "DispChromeAllowDoubleClickFullscreen": true,
+  "DispManagerAR": 1,
+  "DispCustomUserARWidth": -1,
+  "DispCustomUserARHeight": -1,
+  "DispCustomUserArx": -1.0,
+  "DispCustomUserAry": -1.0,
+  "DispCropLeft": 0,
+  "DispCropTop": 0,
+  "DispCropRight": 0,
+  "DispCropBottom": 0,
+  "SoundOutputMethod": 0,
+  "SoundEnabled": true,
+  "SoundEnabledNormal": true,
+  "SoundEnabledRWFF": true,
+  "MuteFrameAdvance": true,
+  "SoundVolume": 100,
+  "SoundVolumeRWFF": 50,
+  "SoundThrottle": false,
+  "SoundDevice": "",
+  "SoundBufferSizeMs": 100,
+  "RecentLua": {
+    "recentlist": [],
+    "MAX_RECENT_FILES": 8,
+    "AutoLoad": false,
+    "Frozen": false
+  },
+  "RecentLuaSession": {
+    "recentlist": [],
+    "MAX_RECENT_FILES": 8,
+    "AutoLoad": false,
+    "Frozen": false
+  },
+  "DisableLuaScriptsOnLoad": false,
+  "RunLuaDuringTurbo": true,
+  "RecentWatches": {
+    "recentlist": [],
+    "MAX_RECENT_FILES": 8,
+    "AutoLoad": false,
+    "Frozen": false
+  },
+  "RamWatchDefinePrevious": 2,
+  "DisplayRamWatch": false,
+  "VideoWriter": "",
+  "JmdCompression": 3,
+  "JmdThreads": 3,
+  "FFmpegFormat": "",
+  "FFmpegCustomCommand": "-c:a foo -c:v bar -f baz",
+  "AviCodecToken": "",
+  "GifWriterFrameskip": 3,
+  "GifWriterDelay": -1,
+  "VideoWriterAudioSync": true,
+  "CoreSettings": {
+    "BizHawk.Emulation.Cores.Nintendo.SNES9X.Snes9x": {
+      "$type": "BizHawk.Emulation.Cores.Nintendo.SNES9X.Snes9x+Settings, BizHawk.Emulation.Cores",
+      "PlaySound0": true,
+      "PlaySound1": true,
+      "PlaySound2": true,
+      "PlaySound3": true,
+      "PlaySound4": true,
+      "PlaySound5": true,
+      "PlaySound6": true,
+      "PlaySound7": true,
+      "ShowBg0": true,
+      "ShowBg1": true,
+      "ShowBg2": true,
+      "ShowBg3": true,
+      "ShowSprites0": true,
+      "ShowSprites1": true,
+      "ShowSprites2": true,
+      "ShowSprites3": true,
+      "ShowWindow": true,
+      "ShowTransparency": true
+    },
+    "BizHawk.Emulation.Cores.Nintendo.SNES.LibsnesCore": {
+      "$type": "BizHawk.Emulation.Cores.Nintendo.SNES.LibsnesCore+SnesSettings, BizHawk.Emulation.Cores",
+      "ShowBG1_0": true,
+      "ShowBG2_0": true,
+      "ShowBG3_0": true,
+      "ShowBG4_0": true,
+      "ShowBG1_1": true,
+      "ShowBG2_1": true,
+      "ShowBG3_1": true,
+      "ShowBG4_1": true,
+      "ShowOBJ_0": true,
+      "ShowOBJ_1": true,
+      "ShowOBJ_2": true,
+      "ShowOBJ_3": true,
+      "CropSGBFrame": false,
+      "AlwaysDoubleSize": false,
+      "Palette": "BizHawk"
+    },
+    "BizHawk.Emulation.Cores.Nintendo.BSNES.BsnesCore": {
+      "$type": "BizHawk.Emulation.Cores.Nintendo.BSNES.BsnesCore+SnesSettings, BizHawk.Emulation.Cores",
+      "ShowBG1_0": true,
+      "ShowBG2_0": true,
+      "ShowBG3_0": true,
+      "ShowBG4_0": true,
+      "ShowBG1_1": true,
+      "ShowBG2_1": true,
+      "ShowBG3_1": true,
+      "ShowBG4_1": true,
+      "ShowOBJ_0": true,
+      "ShowOBJ_1": true,
+      "ShowOBJ_2": true,
+      "ShowOBJ_3": true,
+      "AlwaysDoubleSize": false,
+      "CropSGBFrame": false
+    },
+    "BizHawk.Emulation.Cores.Consoles.Nintendo.Faust.Faust": {
+      "$type": "BizHawk.Emulation.Cores.Waterbox.NymaCore+NymaSettings, BizHawk.Emulation.Cores",
+      "MednafenValues": {},
+      "DisabledLayers": []
+    },
+    "BizHawk.Emulation.Cores.Nintendo.N64.N64": {
+      "$type": "BizHawk.Emulation.Cores.Nintendo.N64.N64Settings, BizHawk.Emulation.Cores",
+      "VideoSizeX": 320,
+      "VideoSizeY": 240,
+      "UseMupenStyleLag": false
+    }
+  },
+  "CoreSyncSettings": {
+    "BizHawk.Emulation.Cores.Nintendo.SNES9X.Snes9x": {
+      "$type": "BizHawk.Emulation.Cores.Nintendo.SNES9X.Snes9x+SyncSettings, BizHawk.Emulation.Cores",
+      "LeftPort": 1,
+      "RightPort": 1
+    },
+    "BizHawk.Emulation.Cores.Nintendo.SNES.LibsnesCore": {
+      "$type": "BizHawk.Emulation.Cores.Nintendo.SNES.LibsnesCore+SnesSyncSettings, BizHawk.Emulation.Cores",
+      "LeftPort": 1,
+      "RightPort": 0,
+      "LimitAnalogChangeSensitivity": true,
+      "RandomizedInitialState": true
+    },
+    "BizHawk.Emulation.Cores.Nintendo.BSNES.BsnesCore": {
+      "$type": "BizHawk.Emulation.Cores.Nintendo.BSNES.BsnesCore+SnesSyncSettings, BizHawk.Emulation.Cores",
+      "LeftPort": 1,
+      "RightPort": 0,
+      "LimitAnalogChangeSensitivity": true,
+      "Entropy": 1,
+      "Hotfixes": true,
+      "FastPPU": true,
+      "UseSGB2": true
+    },
+    "BizHawk.Emulation.Cores.Consoles.Nintendo.Faust.Faust": {
+      "$type": "BizHawk.Emulation.Cores.Waterbox.NymaCore+NymaSyncSettings, BizHawk.Emulation.Cores",
+      "MednafenValues": {},
+      "PortDevices": {}
+    },
+    "BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES.QuickNES": {
+      "$type": "BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES.QuickNES+QuickNESSyncSettings, BizHawk.Emulation.Cores",
+      "LeftPortConnected": true,
+      "RightPortConnected": false
+    },
+    "BizHawk.Emulation.Cores.Nintendo.N64.N64": {
+      "$type": "BizHawk.Emulation.Cores.Nintendo.N64.N64SyncSettings, BizHawk.Emulation.Cores",
+      "Core": 1,
+      "Rsp": 0,
+      "VideoPlugin": 4,
+      "DisableExpansionSlot": true,
+      "Controllers": [
+        {
+          "PakType": 1,
+          "IsConnected": true
+        },
+        {
+          "PakType": 1,
+          "IsConnected": false
+        },
+        {
+          "PakType": 1,
+          "IsConnected": false
+        },
+        {
+          "PakType": 1,
+          "IsConnected": false
+        }
+      ],
+      "RicePlugin": {
+        "FrameBufferSetting": 0,
+        "FrameBufferWriteBackControl": 0,
+        "RenderToTexture": 0,
+        "ScreenUpdateSetting": 4,
+        "Mipmapping": 2,
+        "FogMethod": 0,
+        "ForceTextureFilter": 0,
+        "TextureEnhancement": 0,
+        "TextureEnhancementControl": 0,
+        "TextureQuality": 0,
+        "OpenGLDepthBufferSetting": 16,
+        "MultiSampling": 0,
+        "ColorQuality": 0,
+        "OpenGLRenderSetting": 0,
+        "AnisotropicFiltering": 0,
+        "NormalAlphaBlender": false,
+        "FastTextureLoading": false,
+        "AccurateTextureMapping": true,
+        "InN64Resolution": false,
+        "SaveVRAM": false,
+        "DoubleSizeForSmallTxtrBuf": false,
+        "DefaultCombinerDisable": false,
+        "EnableHacks": true,
+        "WinFrameMode": false,
+        "FullTMEMEmulation": false,
+        "OpenGLVertexClipper": false,
+        "EnableSSE": true,
+        "EnableVertexShader": false,
+        "SkipFrame": false,
+        "TexRectOnly": false,
+        "SmallTextureOnly": false,
+        "LoadHiResCRCOnly": true,
+        "LoadHiResTextures": false,
+        "DumpTexturesToFiles": false,
+        "UseDefaultHacks": true,
+        "DisableTextureCRC": false,
+        "DisableCulling": false,
+        "IncTexRectEdge": false,
+        "ZHack": false,
+        "TextureScaleHack": false,
+        "PrimaryDepthHack": false,
+        "Texture1Hack": false,
+        "FastLoadTile": false,
+        "UseSmallerTexture": false,
+        "VIWidth": -1,
+        "VIHeight": -1,
+        "UseCIWidthAndRatio": 0,
+        "FullTMEM": 0,
+        "TxtSizeMethod2": false,
+        "EnableTxtLOD": false,
+        "FastTextureCRC": 0,
+        "EmulateClear": false,
+        "ForceScreenClear": false,
+        "AccurateTextureMappingHack": 0,
+        "NormalBlender": 0,
+        "DisableBlender": false,
+        "ForceDepthBuffer": false,
+        "DisableObjBG": false,
+        "FrameBufferOption": 0,
+        "RenderToTextureOption": 0,
+        "ScreenUpdateSettingHack": 0,
+        "EnableHacksForGame": 0
+      },
+      "GlidePlugin": {
+        "wfmode": 1,
+        "wireframe": false,
+        "card_id": 0,
+        "flame_corona": false,
+        "ucode": 2,
+        "autodetect_ucode": true,
+        "motionblur": false,
+        "fb_read_always": false,
+        "unk_as_red": false,
+        "filter_cache": false,
+        "fast_crc": false,
+        "disable_auxbuf": false,
+        "fbo": false,
+        "noglsl": true,
+        "noditheredalpha": true,
+        "tex_filter": 0,
+        "fb_render": false,
+        "wrap_big_tex": false,
+        "use_sts1_only": false,
+        "soft_depth_compare": false,
+        "PPL": false,
+        "fb_optimize_write": false,
+        "fb_optimize_texrect": true,
+        "increase_texrect_edge": false,
+        "increase_primdepth": false,
+        "fb_ignore_previous": false,
+        "fb_ignore_aux_copy": false,
+        "fb_hires_buf_clear": true,
+        "force_microcheck": false,
+        "force_depth_compare": false,
+        "fog": true,
+        "fillcolor_fix": false,
+        "fb_smart": false,
+        "fb_read_alpha": false,
+        "fb_get_info": false,
+        "fb_hires": true,
+        "fb_clear": false,
+        "detect_cpu_write": false,
+        "decrease_fillrect_edge": false,
+        "buff_clear": true,
+        "alt_tex_size": false,
+        "UseDefaultHacks": true,
+        "enable_hacks_for_game": 0,
+        "swapmode": 1,
+        "stipple_pattern": 1041204192,
+        "stipple_mode": 2,
+        "scale_y": 100000,
+        "scale_x": 100000,
+        "offset_y": 0,
+        "offset_x": 0,
+        "lodmode": 0,
+        "fix_tex_coord": 0,
+        "filtering": 1,
+        "depth_bias": 20
+      },
+      "Glide64mk2Plugin": {
+        "wrpFBO": true,
+        "card_id": 0,
+        "use_sts1_only": false,
+        "optimize_texrect": true,
+        "increase_texrect_edge": false,
+        "ignore_aux_copy": false,
+        "hires_buf_clear": true,
+        "force_microcheck": false,
+        "fog": true,
+        "fb_smart": false,
+        "fb_read_alpha": false,
+        "fb_hires": true,
+        "detect_cpu_write": false,
+        "decrease_fillrect_edge": false,
+        "buff_clear": true,
+        "alt_tex_size": false,
+        "swapmode": 1,
+        "stipple_pattern": 1041204192,
+        "stipple_mode": 2,
+        "lodmode": 0,
+        "filtering": 0,
+        "wrpAnisotropic": false,
+        "correct_viewport": false,
+        "force_calc_sphere": false,
+        "pal230": false,
+        "texture_correction": true,
+        "n64_z_scale": false,
+        "old_style_adither": false,
+        "zmode_compare_less": false,
+        "adjust_aspect": true,
+        "clip_zmax": true,
+        "clip_zmin": false,
+        "force_quad3d": false,
+        "useless_is_useless": false,
+        "fb_read_always": false,
+        "fb_get_info": false,
+        "fb_render": true,
+        "aspectmode": 0,
+        "fb_crc_mode": 1,
+        "fast_crc": true,
+        "UseDefaultHacks": true,
+        "enable_hacks_for_game": 0,
+        "read_back_to_screen": 0
+      },
+      "GLideN64Plugin": {
+        "BackgroundsMode": 0,
+        "UseDefaultHacks": true,
+        "MultiSampling": 0,
+        "AspectRatio": 1,
+        "BufferSwapMode": 0,
+        "UseNativeResolutionFactor": 0,
+        "bilinearMode": 0,
+        "enableHalosRemoval": false,
+        "MaxAnisotropy": false,
+        "CacheSize": 1000,
+        "ShowInternalResolution": false,
+        "ShowRenderingResolution": false,
+        "FXAA": false,
+        "EnableNoise": false,
+        "EnableLOD": true,
+        "EnableHWLighting": false,
+        "EnableShadersStorage": false,
+        "CorrectTexrectCoords": 0,
+        "EnableNativeResTexrects": false,
+        "EnableLegacyBlending": false,
+        "EnableFragmentDepthWrite": true,
+        "EnableFBEmulation": true,
+        "EnableCopyAuxiliaryToRDRAM": false,
+        "EnableN64DepthCompare": true,
+        "EnableOverscan": false,
+        "OverscanNtscTop": 0,
+        "OverscanNtscBottom": 0,
+        "OverscanNtscLeft": 0,
+        "OverscanNtscRight": 0,
+        "OverscanPalTop": 0,
+        "OverscanPalBottom": 0,
+        "OverscanPalLeft": 0,
+        "OverscanPalRight": 0,
+        "DisableFBInfo": true,
+        "FBInfoReadColorChunk": false,
+        "FBInfoReadDepthChunk": true,
+        "EnableCopyColorToRDRAM": 1,
+        "EnableCopyDepthToRDRAM": 2,
+        "EnableCopyColorFromRDRAM": false,
+        "txFilterMode": 0,
+        "txEnhancementMode": 0,
+        "txDeposterize": false,
+        "txFilterIgnoreBG": false,
+        "txCacheSize": 100,
+        "txHiresEnable": false,
+        "txHiresFullAlphaChannel": false,
+        "txEnhancedTextureFileStorage": false,
+        "txHiresTextureFileStorage": false,
+        "txHresAltCRC": false,
+        "txDump": false,
+        "txCacheCompression": true,
+        "txForce16bpp": false,
+        "txSaveCache": true,
+        "txPath": "",
+        "EnableBloom": false,
+        "bloomThresholdLevel": 0,
+        "bloomBlendMode": 2,
+        "blurAmount": 0,
+        "blurStrength": 0,
+        "ForceGammaCorrection": false,
+        "GammaCorrectionLevel": 0.0
+      }
+    }
+  },
+  "CommonToolSettings": {
+    "BizHawk.Client.EmuHawk.LuaConsole": {
+      "_wndx": 368,
+      "_wndy": 464,
+      "Width": 1590,
+      "Height": 394,
+      "SaveWindowPosition": true,
+      "TopMost": false,
+      "FloatingWindow": true,
+      "AutoLoad": false
+    },
+    "BizHawk.Client.EmuHawk.RamWatch": {
+      "_wndx": 970,
+      "_wndy": 188,
+      "Width": 411,
+      "Height": 417,
+      "SaveWindowPosition": true,
+      "TopMost": false,
+      "FloatingWindow": true,
+      "AutoLoad": false
+    },
+    "BizHawk.Client.EmuHawk.RamSearch": {
+      "_wndx": 156,
+      "_wndy": 156,
+      "Width": 461,
+      "Height": 498,
+      "SaveWindowPosition": true,
+      "TopMost": false,
+      "FloatingWindow": true,
+      "AutoLoad": false
+    }
+  },
+  "CustomToolSettings": {
+    "BizHawk.Client.EmuHawk.LuaConsole": {
+      "Settings": {
+        "$type": "BizHawk.Client.EmuHawk.LuaConsole+LuaConsoleSettings, EmuHawk",
+        "Columns": {
+          "$type": "BizHawk.Client.EmuHawk.RollColumns, EmuHawk",
+          "$values": [
+            {
+              "Group": null,
+              "Width": 22,
+              "Left": 0,
+              "Right": 22,
+              "Name": "Icon",
+              "Text": " ",
+              "Type": 3,
+              "Visible": true,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 92,
+              "Left": 22,
+              "Right": 114,
+              "Name": "Script",
+              "Text": "Script",
+              "Type": 2,
+              "Visible": true,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 300,
+              "Left": 114,
+              "Right": 414,
+              "Name": "PathName",
+              "Text": "Path",
+              "Type": 2,
+              "Visible": true,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            }
+          ]
+        },
+        "ReloadOnScriptFileChange": false,
+        "ToggleAllIfNoneSelected": true,
+        "SplitDistance": 754,
+        "DisableLuaScriptsOnLoad": false
+      }
+    },
+    "BizHawk.Client.EmuHawk.RamWatch": {
+      "Settings": {
+        "$type": "BizHawk.Client.EmuHawk.RamWatch+RamWatchSettings, EmuHawk",
+        "Columns": {
+          "$type": "BizHawk.Client.EmuHawk.RollColumns, EmuHawk",
+          "$values": [
+            {
+              "Group": null,
+              "Width": 60,
+              "Left": 0,
+              "Right": 60,
+              "Name": "AddressColumn",
+              "Text": "Address",
+              "Type": 2,
+              "Visible": true,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 59,
+              "Left": 60,
+              "Right": 119,
+              "Name": "ValueColumn",
+              "Text": "Value",
+              "Type": 2,
+              "Visible": true,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 59,
+              "Left": 0,
+              "Right": 0,
+              "Name": "PrevColumn",
+              "Text": "Prev",
+              "Type": 2,
+              "Visible": false,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 60,
+              "Left": 119,
+              "Right": 179,
+              "Name": "ChangesColumn",
+              "Text": "Changes",
+              "Type": 2,
+              "Visible": true,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 59,
+              "Left": 0,
+              "Right": 0,
+              "Name": "DiffColumn",
+              "Text": "Diff",
+              "Type": 2,
+              "Visible": false,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 55,
+              "Left": 0,
+              "Right": 0,
+              "Name": "TypeColumn",
+              "Text": "Type",
+              "Type": 2,
+              "Visible": false,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 55,
+              "Left": 179,
+              "Right": 234,
+              "Name": "DomainColumn",
+              "Text": "Domain",
+              "Type": 2,
+              "Visible": true,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 128,
+              "Left": 234,
+              "Right": 362,
+              "Name": "NotesColumn",
+              "Text": "Notes",
+              "Type": 2,
+              "Visible": true,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            }
+          ]
+        }
+      }
+    },
+    "BizHawk.Client.EmuHawk.RamSearch": {
+      "Settings": {
+        "$type": "BizHawk.Client.EmuHawk.RamSearch+RamSearchSettings, EmuHawk",
+        "Columns": {
+          "$type": "BizHawk.Client.EmuHawk.RollColumns, EmuHawk",
+          "$values": [
+            {
+              "Group": null,
+              "Width": 60,
+              "Left": 0,
+              "Right": 60,
+              "Name": "AddressColumn",
+              "Text": "Address",
+              "Type": 2,
+              "Visible": true,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 59,
+              "Left": 60,
+              "Right": 119,
+              "Name": "ValueColumn",
+              "Text": "Value",
+              "Type": 2,
+              "Visible": true,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 59,
+              "Left": 119,
+              "Right": 178,
+              "Name": "PrevColumn",
+              "Text": "Prev",
+              "Type": 2,
+              "Visible": true,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 60,
+              "Left": 178,
+              "Right": 238,
+              "Name": "ChangesColumn",
+              "Text": "Changes",
+              "Type": 2,
+              "Visible": true,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            },
+            {
+              "Group": null,
+              "Width": 59,
+              "Left": 0,
+              "Right": 0,
+              "Name": "DiffColumn",
+              "Text": "Diff",
+              "Type": 2,
+              "Visible": false,
+              "Emphasis": false,
+              "Rotatable": false,
+              "RotatedHeight": null
+            }
+          ]
+        },
+        "PreviewMode": true,
+        "AlwaysExcludeRamWatch": false,
+        "AutoSearchTakeLagFramesIntoAccount": true,
+        "UseUndoHistory": true,
+        "RecentSearches": {
+          "recentlist": [],
+          "MAX_RECENT_FILES": 8,
+          "AutoLoad": false,
+          "Frozen": false
+        }
+      }
+    }
+  },
+  "Cheats": {
+    "DisableOnLoad": false,
+    "LoadFileByGame": true,
+    "AutoSaveOnClose": true,
+    "Recent": {
+      "recentlist": [],
+      "MAX_RECENT_FILES": 8,
+      "AutoLoad": false,
+      "Frozen": false
+    }
+  },
+  "RecentMacros": {
+    "recentlist": [],
+    "MAX_RECENT_FILES": 8,
+    "AutoLoad": false,
+    "Frozen": false
+  },
+  "RecentMovies": {
+    "recentlist": [],
+    "MAX_RECENT_FILES": 8,
+    "AutoLoad": false,
+    "Frozen": false
+  },
+  "DefaultAuthor": "default user",
+  "UseDefaultAuthor": true,
+  "DisplaySubtitles": true,
+  "PlayMovieIncludeSubDir": false,
+  "PlayMovieMatchHash": true,
+  "Ti83AutoloadKeyPad": true,
+  "HotkeyBindings": {
+    "Bindings": [
+      {
+        "DisplayName": "Frame Advance",
+        "Bindings": "F",
+        "DefaultBinding": "F",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 0
+      },
+      {
+        "DisplayName": "Rewind",
+        "Bindings": "Shift+R",
+        "DefaultBinding": "Shift+R",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 1
+      },
+      {
+        "DisplayName": "Pause",
+        "Bindings": "P",
+        "DefaultBinding": "Pause",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 2
+      },
+      {
+        "DisplayName": "Fast Forward",
+        "Bindings": "Tab",
+        "DefaultBinding": "Tab",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 3
+      },
+      {
+        "DisplayName": "Turbo",
+        "Bindings": "Shift+Tab",
+        "DefaultBinding": "Shift+Tab",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 4
+      },
+      {
+        "DisplayName": "Toggle Throttle",
+        "Bindings": "T",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 5
+      },
+      {
+        "DisplayName": "Soft Reset",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 6
+      },
+      {
+        "DisplayName": "Hard Reset",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 7
+      },
+      {
+        "DisplayName": "Autofire",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 8
+      },
+      {
+        "DisplayName": "Autohold",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 9
+      },
+      {
+        "DisplayName": "Clear Autohold",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 10
+      },
+      {
+        "DisplayName": "Screenshot",
+        "Bindings": "F12",
+        "DefaultBinding": "F12",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 11
+      },
+      {
+        "DisplayName": "Full Screen",
+        "Bindings": "Alt+Enter",
+        "DefaultBinding": "Alt+Enter",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 12
+      },
+      {
+        "DisplayName": "Open ROM",
+        "Bindings": "Ctrl+O",
+        "DefaultBinding": "Ctrl+O",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 13
+      },
+      {
+        "DisplayName": "Close ROM",
+        "Bindings": "Ctrl+W",
+        "DefaultBinding": "Ctrl+W",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 14
+      },
+      {
+        "DisplayName": "Load Last ROM",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 15
+      },
+      {
+        "DisplayName": "Flush SaveRAM",
+        "Bindings": "Ctrl+S",
+        "DefaultBinding": "Ctrl+S",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 16
+      },
+      {
+        "DisplayName": "Display FPS",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 17
+      },
+      {
+        "DisplayName": "Frame Counter",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 18
+      },
+      {
+        "DisplayName": "Lag Counter",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 19
+      },
+      {
+        "DisplayName": "Input Display",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 20
+      },
+      {
+        "DisplayName": "Toggle BG Input",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 21
+      },
+      {
+        "DisplayName": "Toggle Menu",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 22
+      },
+      {
+        "DisplayName": "Volume Up",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 23
+      },
+      {
+        "DisplayName": "Volume Down",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 24
+      },
+      {
+        "DisplayName": "Record A/V",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 25
+      },
+      {
+        "DisplayName": "Stop A/V",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 26
+      },
+      {
+        "DisplayName": "Larger Window",
+        "Bindings": "Alt+Up",
+        "DefaultBinding": "Alt+Up",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 27
+      },
+      {
+        "DisplayName": "Smaller Window",
+        "Bindings": "Alt+Down",
+        "DefaultBinding": "Alt+Down",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 28
+      },
+      {
+        "DisplayName": "Increase Speed",
+        "Bindings": "Equals",
+        "DefaultBinding": "Equals",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 29
+      },
+      {
+        "DisplayName": "Decrease Speed",
+        "Bindings": "Minus",
+        "DefaultBinding": "Minus",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 30
+      },
+      {
+        "DisplayName": "Reset Speed",
+        "Bindings": "Shift+Equals",
+        "DefaultBinding": "Shift+Equals",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 31
+      },
+      {
+        "DisplayName": "Reboot Core",
+        "Bindings": "Ctrl+R",
+        "DefaultBinding": "Ctrl+R",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 32
+      },
+      {
+        "DisplayName": "Toggle Sound",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 33
+      },
+      {
+        "DisplayName": "Exit Program",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 34
+      },
+      {
+        "DisplayName": "Screen Raw to Clipboard",
+        "Bindings": "Ctrl+C",
+        "DefaultBinding": "Ctrl+C",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 35
+      },
+      {
+        "DisplayName": "Screen Client to Clipboard",
+        "Bindings": "Ctrl+Shift+C",
+        "DefaultBinding": "Ctrl+Shift+C",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 36
+      },
+      {
+        "DisplayName": "Toggle Skip Lag Frame",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 37
+      },
+      {
+        "DisplayName": "Toggle Key Priority",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 38
+      },
+      {
+        "DisplayName": "Frame Inch",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "General",
+        "ToolTip": "",
+        "Ordinal": 39
+      },
+      {
+        "DisplayName": "Save State 0",
+        "Bindings": "Shift+F10",
+        "DefaultBinding": "Shift+F10",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 40
+      },
+      {
+        "DisplayName": "Save State 1",
+        "Bindings": "Shift+F1",
+        "DefaultBinding": "Shift+F1",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 41
+      },
+      {
+        "DisplayName": "Save State 2",
+        "Bindings": "Shift+F2",
+        "DefaultBinding": "Shift+F2",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 42
+      },
+      {
+        "DisplayName": "Save State 3",
+        "Bindings": "Shift+F3",
+        "DefaultBinding": "Shift+F3",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 43
+      },
+      {
+        "DisplayName": "Save State 4",
+        "Bindings": "Shift+F4",
+        "DefaultBinding": "Shift+F4",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 44
+      },
+      {
+        "DisplayName": "Save State 5",
+        "Bindings": "Shift+F5",
+        "DefaultBinding": "Shift+F5",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 45
+      },
+      {
+        "DisplayName": "Save State 6",
+        "Bindings": "Shift+F6",
+        "DefaultBinding": "Shift+F6",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 46
+      },
+      {
+        "DisplayName": "Save State 7",
+        "Bindings": "Shift+F7",
+        "DefaultBinding": "Shift+F7",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 47
+      },
+      {
+        "DisplayName": "Save State 8",
+        "Bindings": "Shift+F8",
+        "DefaultBinding": "Shift+F8",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 48
+      },
+      {
+        "DisplayName": "Save State 9",
+        "Bindings": "Shift+F9",
+        "DefaultBinding": "Shift+F9",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 49
+      },
+      {
+        "DisplayName": "Load State 0",
+        "Bindings": "F10",
+        "DefaultBinding": "F10",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 50
+      },
+      {
+        "DisplayName": "Load State 1",
+        "Bindings": "F1",
+        "DefaultBinding": "F1",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 51
+      },
+      {
+        "DisplayName": "Load State 2",
+        "Bindings": "F2",
+        "DefaultBinding": "F2",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 52
+      },
+      {
+        "DisplayName": "Load State 3",
+        "Bindings": "F3",
+        "DefaultBinding": "F3",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 53
+      },
+      {
+        "DisplayName": "Load State 4",
+        "Bindings": "F4",
+        "DefaultBinding": "F4",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 54
+      },
+      {
+        "DisplayName": "Load State 5",
+        "Bindings": "F5",
+        "DefaultBinding": "F5",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 55
+      },
+      {
+        "DisplayName": "Load State 6",
+        "Bindings": "F6",
+        "DefaultBinding": "F6",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 56
+      },
+      {
+        "DisplayName": "Load State 7",
+        "Bindings": "F7",
+        "DefaultBinding": "F7",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 57
+      },
+      {
+        "DisplayName": "Load State 8",
+        "Bindings": "F8",
+        "DefaultBinding": "F8",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 58
+      },
+      {
+        "DisplayName": "Load State 9",
+        "Bindings": "F9",
+        "DefaultBinding": "F9",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 59
+      },
+      {
+        "DisplayName": "Select State 0",
+        "Bindings": "Number0",
+        "DefaultBinding": "Number0",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 60
+      },
+      {
+        "DisplayName": "Select State 1",
+        "Bindings": "Number1",
+        "DefaultBinding": "Number1",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 61
+      },
+      {
+        "DisplayName": "Select State 2",
+        "Bindings": "Number2",
+        "DefaultBinding": "Number2",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 62
+      },
+      {
+        "DisplayName": "Select State 3",
+        "Bindings": "Number3",
+        "DefaultBinding": "Number3",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 63
+      },
+      {
+        "DisplayName": "Select State 4",
+        "Bindings": "Number4",
+        "DefaultBinding": "Number4",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 64
+      },
+      {
+        "DisplayName": "Select State 5",
+        "Bindings": "Number5",
+        "DefaultBinding": "Number5",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 65
+      },
+      {
+        "DisplayName": "Select State 6",
+        "Bindings": "Number6",
+        "DefaultBinding": "Number6",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 66
+      },
+      {
+        "DisplayName": "Select State 7",
+        "Bindings": "Number7",
+        "DefaultBinding": "Number7",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 67
+      },
+      {
+        "DisplayName": "Select State 8",
+        "Bindings": "Number8",
+        "DefaultBinding": "Number8",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 68
+      },
+      {
+        "DisplayName": "Select State 9",
+        "Bindings": "Number9",
+        "DefaultBinding": "Number9",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 69
+      },
+      {
+        "DisplayName": "Quick Load",
+        "Bindings": "",
+        "DefaultBinding": "P",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 70
+      },
+      {
+        "DisplayName": "Quick Save",
+        "Bindings": "I",
+        "DefaultBinding": "I",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 71
+      },
+      {
+        "DisplayName": "Save Named State",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 72
+      },
+      {
+        "DisplayName": "Load Named State",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 73
+      },
+      {
+        "DisplayName": "Previous Slot",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 74
+      },
+      {
+        "DisplayName": "Next Slot",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Save States",
+        "ToolTip": "",
+        "Ordinal": 75
+      },
+      {
+        "DisplayName": "Toggle read-only",
+        "Bindings": "Q",
+        "DefaultBinding": "Q",
+        "TabGroup": "Movie",
+        "ToolTip": "",
+        "Ordinal": 76
+      },
+      {
+        "DisplayName": "Play Movie",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Movie",
+        "ToolTip": "",
+        "Ordinal": 77
+      },
+      {
+        "DisplayName": "Record Movie",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Movie",
+        "ToolTip": "",
+        "Ordinal": 78
+      },
+      {
+        "DisplayName": "Stop Movie",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Movie",
+        "ToolTip": "",
+        "Ordinal": 79
+      },
+      {
+        "DisplayName": "Play from beginning",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Movie",
+        "ToolTip": "",
+        "Ordinal": 80
+      },
+      {
+        "DisplayName": "Save Movie",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Movie",
+        "ToolTip": "",
+        "Ordinal": 81
+      },
+      {
+        "DisplayName": "RAM Watch",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Tools",
+        "ToolTip": "",
+        "Ordinal": 82
+      },
+      {
+        "DisplayName": "RAM Search",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Tools",
+        "ToolTip": "",
+        "Ordinal": 83
+      },
+      {
+        "DisplayName": "Hex Editor",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Tools",
+        "ToolTip": "",
+        "Ordinal": 84
+      },
+      {
+        "DisplayName": "Trace Logger",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Tools",
+        "ToolTip": "",
+        "Ordinal": 85
+      },
+      {
+        "DisplayName": "Lua Console",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Tools",
+        "ToolTip": "",
+        "Ordinal": 86
+      },
+      {
+        "DisplayName": "Cheats",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Tools",
+        "ToolTip": "",
+        "Ordinal": 87
+      },
+      {
+        "DisplayName": "TAStudio",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Tools",
+        "ToolTip": "",
+        "Ordinal": 88
+      },
+      {
+        "DisplayName": "ToolBox",
+        "Bindings": "Shift+T",
+        "DefaultBinding": "Shift+T",
+        "TabGroup": "Tools",
+        "ToolTip": "",
+        "Ordinal": 89
+      },
+      {
+        "DisplayName": "Virtual Pad",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Tools",
+        "ToolTip": "",
+        "Ordinal": 90
+      },
+      {
+        "DisplayName": "New Search",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "RAM Search",
+        "ToolTip": "",
+        "Ordinal": 91
+      },
+      {
+        "DisplayName": "Do Search",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "RAM Search",
+        "ToolTip": "",
+        "Ordinal": 92
+      },
+      {
+        "DisplayName": "Previous Compare To",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "RAM Search",
+        "ToolTip": "",
+        "Ordinal": 93
+      },
+      {
+        "DisplayName": "Next Compare To",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "RAM Search",
+        "ToolTip": "",
+        "Ordinal": 94
+      },
+      {
+        "DisplayName": "Previous Operator",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "RAM Search",
+        "ToolTip": "",
+        "Ordinal": 95
+      },
+      {
+        "DisplayName": "Next Operator",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "RAM Search",
+        "ToolTip": "",
+        "Ordinal": 96
+      },
+      {
+        "DisplayName": "Add Branch",
+        "Bindings": "Alt+Insert",
+        "DefaultBinding": "Alt+Insert",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 97
+      },
+      {
+        "DisplayName": "Delete Branch",
+        "Bindings": "Alt+Delete",
+        "DefaultBinding": "Alt+Delete",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 98
+      },
+      {
+        "DisplayName": "Show Cursor",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 99
+      },
+      {
+        "DisplayName": "Toggle Follow Cursor",
+        "Bindings": "Shift+F",
+        "DefaultBinding": "Shift+F",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 100
+      },
+      {
+        "DisplayName": "Toggle Auto-Restore",
+        "Bindings": "Shift+R",
+        "DefaultBinding": "Shift+R",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 101
+      },
+      {
+        "DisplayName": "Toggle Turbo Seek",
+        "Bindings": "Shift+S",
+        "DefaultBinding": "Shift+S",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 102
+      },
+      {
+        "DisplayName": "Undo",
+        "Bindings": "Ctrl+Z",
+        "DefaultBinding": "Ctrl+Z",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 103
+      },
+      {
+        "DisplayName": "Redo",
+        "Bindings": "Ctrl+Y",
+        "DefaultBinding": "Ctrl+Y",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 104
+      },
+      {
+        "DisplayName": "Sel. bet. Markers",
+        "Bindings": "Ctrl+A",
+        "DefaultBinding": "Ctrl+A",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 105
+      },
+      {
+        "DisplayName": "Select All",
+        "Bindings": "Ctrl+Shift+A",
+        "DefaultBinding": "Ctrl+Shift+A",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 106
+      },
+      {
+        "DisplayName": "Reselect Clip.",
+        "Bindings": "Ctrl+B",
+        "DefaultBinding": "Ctrl+B",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 107
+      },
+      {
+        "DisplayName": "Clear Frames",
+        "Bindings": "Delete",
+        "DefaultBinding": "Delete",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 108
+      },
+      {
+        "DisplayName": "Insert Frame",
+        "Bindings": "Insert",
+        "DefaultBinding": "Insert",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 109
+      },
+      {
+        "DisplayName": "Insert # Frames",
+        "Bindings": "Ctrl+Shift+Insert",
+        "DefaultBinding": "Ctrl+Shift+Insert",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 110
+      },
+      {
+        "DisplayName": "Delete Frames",
+        "Bindings": "Ctrl+Delete",
+        "DefaultBinding": "Ctrl+Delete",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 111
+      },
+      {
+        "DisplayName": "Clone Frames",
+        "Bindings": "Ctrl+Insert",
+        "DefaultBinding": "Ctrl+Insert",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 112
+      },
+      {
+        "DisplayName": "Analog Increment",
+        "Bindings": "Up",
+        "DefaultBinding": "Up",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 113
+      },
+      {
+        "DisplayName": "Analog Decrement",
+        "Bindings": "Down",
+        "DefaultBinding": "Down",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 114
+      },
+      {
+        "DisplayName": "Analog Incr. by 10",
+        "Bindings": "Shift+Up",
+        "DefaultBinding": "Shift+Up",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 115
+      },
+      {
+        "DisplayName": "Analog Decr. by 10",
+        "Bindings": "Shift+Down",
+        "DefaultBinding": "Shift+Down",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 116
+      },
+      {
+        "DisplayName": "Analog Maximum",
+        "Bindings": "Right",
+        "DefaultBinding": "Right",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 117
+      },
+      {
+        "DisplayName": "Analog Minimum",
+        "Bindings": "Left",
+        "DefaultBinding": "Left",
+        "TabGroup": "TAStudio",
+        "ToolTip": "",
+        "Ordinal": 118
+      },
+      {
+        "DisplayName": "Toggle BG 1",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "SNES",
+        "ToolTip": "",
+        "Ordinal": 119
+      },
+      {
+        "DisplayName": "Toggle BG 2",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "SNES",
+        "ToolTip": "",
+        "Ordinal": 120
+      },
+      {
+        "DisplayName": "Toggle BG 3",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "SNES",
+        "ToolTip": "",
+        "Ordinal": 121
+      },
+      {
+        "DisplayName": "Toggle BG 4",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "SNES",
+        "ToolTip": "",
+        "Ordinal": 122
+      },
+      {
+        "DisplayName": "Toggle OBJ 1",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "SNES",
+        "ToolTip": "",
+        "Ordinal": 123
+      },
+      {
+        "DisplayName": "Toggle OBJ 2",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "SNES",
+        "ToolTip": "",
+        "Ordinal": 124
+      },
+      {
+        "DisplayName": "Toggle OBJ 3",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "SNES",
+        "ToolTip": "",
+        "Ordinal": 125
+      },
+      {
+        "DisplayName": "Toggle OBJ 4",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "SNES",
+        "ToolTip": "",
+        "Ordinal": 126
+      },
+      {
+        "DisplayName": "GB Toggle BG",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "GB",
+        "ToolTip": "",
+        "Ordinal": 127
+      },
+      {
+        "DisplayName": "GB Toggle Obj",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "GB",
+        "ToolTip": "",
+        "Ordinal": 128
+      },
+      {
+        "DisplayName": "GB Toggle Window",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "GB",
+        "ToolTip": "",
+        "Ordinal": 129
+      },
+      {
+        "DisplayName": "Y Up Small",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Analog",
+        "ToolTip": "For Virtual Pad",
+        "Ordinal": 130
+      },
+      {
+        "DisplayName": "Y Up Large",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Analog",
+        "ToolTip": "For Virtual Pad",
+        "Ordinal": 131
+      },
+      {
+        "DisplayName": "Y Down Small",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Analog",
+        "ToolTip": "For Virtual Pad",
+        "Ordinal": 132
+      },
+      {
+        "DisplayName": "Y Down Large",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Analog",
+        "ToolTip": "For Virtual Pad",
+        "Ordinal": 133
+      },
+      {
+        "DisplayName": "X Up Small",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Analog",
+        "ToolTip": "For Virtual Pad",
+        "Ordinal": 134
+      },
+      {
+        "DisplayName": "X Up Large",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Analog",
+        "ToolTip": "For Virtual Pad",
+        "Ordinal": 135
+      },
+      {
+        "DisplayName": "X Down Small",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Analog",
+        "ToolTip": "For Virtual Pad",
+        "Ordinal": 136
+      },
+      {
+        "DisplayName": "X Down Large",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Analog",
+        "ToolTip": "For Virtual Pad",
+        "Ordinal": 137
+      },
+      {
+        "DisplayName": "Toggle All Cheats",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "Tools",
+        "ToolTip": "",
+        "Ordinal": 138
+      },
+      {
+        "DisplayName": "Next Screen Layout",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "NDS",
+        "ToolTip": "",
+        "Ordinal": 139
+      },
+      {
+        "DisplayName": "Previous Screen Layout",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "NDS",
+        "ToolTip": "",
+        "Ordinal": 140
+      },
+      {
+        "DisplayName": "Screen Rotate",
+        "Bindings": "",
+        "DefaultBinding": "",
+        "TabGroup": "NDS",
+        "ToolTip": "",
+        "Ordinal": 141
+      }
+    ]
+  },
+  "AnalogLargeChange": 10,
+  "AnalogSmallChange": 1,
+  "AllTrollers": {
+    "LibRetro Controls": {
+      "P1 RetroPad Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 RetroPad Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 RetroPad Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 RetroPad Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 RetroPad Select": "Space, J1 B9, X1 Back",
+      "P1 RetroPad Start": "Enter, J1 B10, X1 Start",
+      "P1 RetroPad Y": "A, J1 B1, X1 X",
+      "P1 RetroPad B": "Z, J1 B2, X1 A",
+      "P1 RetroPad X": "S, J1 B4, X1 Y",
+      "P1 RetroPad A": "X, J1 B3, X1 B",
+      "P1 RetroPad L": "W, J1 B5, X1 LeftShoulder",
+      "P1 RetroPad R": "E, J1 B6, X1 RightShoulder",
+      "Pointer Pressed": "WMouse L",
+      "Key Backspace": "Backspace",
+      "Key Tab": "Tab",
+      "Key Return": "Enter",
+      "Key Escape": "Escape",
+      "Key Space": "Space",
+      "Key Comma": "Comma",
+      "Key Minus": "Minus",
+      "Key Period": "Period",
+      "Key Slash": "Slash",
+      "Key 0": "Number0",
+      "Key 1": "Number1",
+      "Key 2": "Number2",
+      "Key 3": "Number3",
+      "Key 4": "Number4",
+      "Key 5": "Number5",
+      "Key 6": "Number6",
+      "Key 7": "Number7",
+      "Key 8": "Number8",
+      "Key 9": "Number9",
+      "Key Semicolon": "Semicolon",
+      "Key Equals": "Equals",
+      "Key LeftBracket": "LeftBracket",
+      "Key Backslash": "Backslash",
+      "Key RightBracket": "RightBracket",
+      "Key Backquote": "Backtick",
+      "Key A": "A",
+      "Key B": "B",
+      "Key C": "C",
+      "Key D": "D",
+      "Key E": "E",
+      "Key F": "F",
+      "Key G": "G",
+      "Key H": "H",
+      "Key I": "I",
+      "Key J": "J",
+      "Key K": "K",
+      "Key L": "L",
+      "Key M": "M",
+      "Key N": "N",
+      "Key O": "O",
+      "Key P": "P",
+      "Key Q": "Q",
+      "Key R": "R",
+      "Key S": "S",
+      "Key T": "T",
+      "Key U": "U",
+      "Key V": "V",
+      "Key W": "W",
+      "Key X": "X",
+      "Key Y": "Y",
+      "Key Z": "Z",
+      "Key Delete": "Delete",
+      "Key KP0": "Keypad0",
+      "Key KP1": "Keypad1",
+      "Key KP2": "Keypad2",
+      "Key KP3": "Keypad3",
+      "Key KP4": "Keypad4",
+      "Key KP5": "Keypad5",
+      "Key KP6": "Keypad6",
+      "Key KP7": "Keypad7",
+      "Key KP8": "Keypad8",
+      "Key KP9": "Keypad9",
+      "Key KP_Period": "KeypadDecimal",
+      "Key KP_Divide": "KeypadDivide",
+      "Key KP_Multiply": "KeypadMultiply",
+      "Key KP_Minus": "KeypadSubtract",
+      "Key KP_Plus": "KeypadAdd",
+      "Key KP_Enter": "KeypadEnter",
+      "Key Up": "Up",
+      "Key Down": "Down",
+      "Key Left": "Left",
+      "Key Insert": "LeftCtrl",
+      "Key Home": "Home",
+      "Key End": "End",
+      "Key PageUp": "PageUp",
+      "Key PageDown": "PageDown",
+      "Key F1": "F1",
+      "Key F2": "F2",
+      "Key F3": "F3",
+      "Key F4": "F4",
+      "Key F5": "F5",
+      "Key F6": "F6",
+      "Key F7": "F7",
+      "Key F8": "F8",
+      "Key F9": "F9",
+      "Key F10": "F10",
+      "Key F11": "F11",
+      "Key F12": "F12",
+      "Key NumLock": "NumLock",
+      "Key CapsLock": "CapsLock",
+      "Key ScrollLock": "ScrollLock",
+      "Key RShift": "RightShift",
+      "Key LShift": "LeftShift",
+      "Key RCtrl": "RightCtrl",
+      "Key LCtrl": "LeftCtrl",
+      "Key RAlt": "RightAlt",
+      "Key LAlt": "LeftAlt",
+      "Key Menu": "Apps",
+      "Key Right": "Right"
+    },
+    "NES Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Start": "Enter, J1 B10, X1 Start",
+      "P1 Select": "Space, J1 B9, X1 Back",
+      "P1 B": "Z, J1 B1, X1 X",
+      "P1 A": "X, J1 B2, X1 A",
+      "P2 Fire": "WMouse L",
+      "P3 Fire": "WMouse L"
+    },
+    "SNES Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Select": "Space, J1 B9, X1 Back",
+      "P1 Start": "Enter, J1 B10, X1 Start",
+      "P1 Y": "A, J1 B1, X1 X",
+      "P1 X": "S, J1 B4, X1 Y",
+      "P1 B": "Z, J1 B2, X1 A",
+      "P1 A": "X, J1 B3, X1 B",
+      "P1 L": "W, J1 B5, X1 LeftShoulder",
+      "P1 R": "E, J1 B6, X1 RightShoulder",
+      "P1 Mouse Left": "Z, J1 B1, X1 X",
+      "P1 Mouse Right": "X, J1 B2, X1 A",
+      "P2 Trigger": "Z, J1 B1, X1 X",
+      "P2 Cursor": "X, J1 B2, X1 A",
+      "P2 Turbo": "A, J1 B3 X1 Y",
+      "P2 Pause": "S, J1 B4 X1 B"
+    },
+    "Nintendo 64 Controller": {
+      "P1 A Up": "Up, J1 POV1U",
+      "P1 A Down": "Down, J1 POV1D",
+      "P1 A Left": "Left, J1 POV1L",
+      "P1 A Right": "Right, J1 POV1R",
+      "P1 DPad U": "X1 DpadUp",
+      "P1 DPad D": "X1 DpadDown",
+      "P1 DPad L": "X1 DpadLeft",
+      "P1 DPad R": "X1 DpadRight",
+      "P1 Start": "Enter, J1 B10, X1 Start",
+      "P1 Z": "D, J1 B3, X1 B",
+      "P1 B": "S, J1 B1, X1 X",
+      "P1 A": "A, J1 B2, X1 A",
+      "P1 C Up": "Keypad8, J1 RotationZ-, X1 RStickUp",
+      "P1 C Down": "Keypad2, J1 RotationZ+, X1 RStickDown",
+      "P1 C Left": "Keypad4, J1 Z-, X1 RStickLeft",
+      "P1 C Right": "Keypad6, J1 Z+, X1 RStickRight",
+      "P1 L": "Q, J1 B5, X1 LeftShoulder",
+      "P1 R": "W, J1 B6, X1 RightShoulder"
+    },
+    "Gameboy Controller": {
+      "Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "Start": "Enter, J1 B10, X1 Start",
+      "Select": "Space, J1 B9, X1 Back",
+      "B": "Z, J1 B1, X1 X",
+      "A": "X, J1 B2, X1 A",
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Start": "Enter, J1 B10, X1 Start",
+      "P1 Select": "Space, J1 B9, X1 Back",
+      "P1 B": "Z, J1 B1, X1 X",
+      "P1 A": "X, J1 B2, X1 A"
+    },
+    "Gameboy Controller H": {
+      "Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "Start": "Enter, J1 B10, X1 Start",
+      "Select": "Space, J1 B9, X1 Back",
+      "B": "Z, J1 B1, X1 X",
+      "A": "X, J1 B2, X1 A",
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Start": "Enter, J1 B10, X1 Start",
+      "P1 Select": "Space, J1 B9, X1 Back",
+      "P1 B": "Z, J1 B1, X1 X",
+      "P1 A": "X, J1 B2, X1 A"
+    },
+    "GBA Controller": {
+      "Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "Start": "Enter, J1 B10, X1 Start",
+      "Select": "Space, J1 B9, X1 Back",
+      "B": "Z, J1 B1, X1 X",
+      "A": "X, J1 B2, X1 A",
+      "L": "W, J1 B5, X1 LeftShoulder",
+      "R": "E, J1 B6, X1 RightShoulder"
+    },
+    "NDS Controller": {
+      "A": "X, J1 B3, X1 B",
+      "B": "Z, J1 B2, X1 A",
+      "X": "S, J1 B4, X1 Y",
+      "Y": "A, J1 B1, X1 X",
+      "Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "L": "W, J1 B5, X1 LeftShoulder",
+      "R": "E, J1 B6, X1 RightShoulder",
+      "Select": "Space, J1 B9, X1 Back",
+      "Start": "Enter, J1 B10, X1 Start",
+      "Touch": "WMouse L"
+    },
+    "Atari 2600 Basic Controller": {
+      "Reset": "D, J1 B9, X1 Back",
+      "Select": "S, J1 B10, X1 Start",
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Button": "Z, J1 B1, X1 X",
+      "P2 Up": "Keypad8, J1 RotationZ-, X1 RStickUp",
+      "P2 Down": "Keypad2, J1 RotationZ+, X1 RStickDown",
+      "P2 Left": "Keypad4, J1 Z-, X1 RStickLeft",
+      "P2 Right": "Keypad6, J1 Z+, X1 RStickRight",
+      "P2 Button": "Keypad1, J1 B2, X1 A"
+    },
+    "Atari 7800 Basic Controller": {
+      "Reset": "D, J1 B9, X1 Back",
+      "Select": "S, J1 B10, X1 Start",
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Button": "Z, J1 B1, X1 X",
+      "P2 Up": "Keypad8, J1 RotationZ-, X1 RStickUp",
+      "P2 Down": "Keypad2, J1 RotationZ+, X1 RStickDown",
+      "P2 Left": "Keypad4, J1 Z-, X1 RStickLeft",
+      "P2 Right": "Keypad6, J1 Z+, X1 RStickRight",
+      "P2 Button": "Keypad1, J1 B2, X1 A"
+    },
+    "Atari 7800 ProLine Joystick Controller": {
+      "Reset": "D, J1 B9, X1 Back",
+      "Select": "S, J1 B10, X1 Start",
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Trigger": "Z, J1 B1, X1 X",
+      "P1 Trigger 2": "X, J1 B2, X1 A",
+      "P2 Up": "Keypad8, J1 RotationZ-, X1 RStickUp",
+      "P2 Down": "Keypad2, J1 RotationZ+, X1 RStickDown",
+      "P2 Left": "Keypad4, J1 Z-, X1 RStickLeft",
+      "P2 Right": "Keypad6, J1 Z+, X1 RStickRight",
+      "P2 Trigger": "Keypad1, J1 B4, X1 Y",
+      "P2 Trigger 2": "Keypad3, J1 B3, X1 B"
+    },
+    "Atari 7800 Joystick Controller": {
+      "Reset": "D, J1 B9, X1 Back",
+      "Select": "S, J1 B10, X1 Start",
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Trigger": "Z, J1 B1, X1 X",
+      "P1 Trigger 2": "X, J1 B2, X1 A",
+      "P2 Up": "Keypad8, J1 RotationZ-, X1 RStickUp",
+      "P2 Down": "Keypad2, J1 RotationZ+, X1 RStickDown",
+      "P2 Left": "Keypad4, J1 Z-, X1 RStickLeft",
+      "P2 Right": "Keypad6, J1 Z+, X1 RStickRight",
+      "P2 Trigger": "Keypad1, J1 B4, X1 Y"
+    },
+    "Atari 7800 Light Gun Controller": {
+      "Reset": "D, J1 B9, X1 Back",
+      "Select": "S, J1 B10, X1 Start",
+      "P1 Trigger": "WMouse L"
+    },
+    "Atari 7800 Paddle Controller": {
+      "Reset": "D, J1 B9, X1 Back",
+      "Select": "S, J1 B10, X1 Start",
+      "P2 Trigger": "Keypad1, J1 B4, X1 Y"
+    },
+    "Commodore 64 Controller": {
+      "P1 Up": "Keypad8, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Keypad2, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Keypad4, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Keypad6, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Button": "Keypad1, J1 B1, X1 X",
+      "Key F1": "F1",
+      "Key F3": "F3",
+      "Key F5": "F5",
+      "Key F7": "F7",
+      "Key Left Arrow": "Backtick",
+      "Key 1": "Number1",
+      "Key 2": "Number2",
+      "Key 3": "Number3",
+      "Key 4": "Number4",
+      "Key 5": "Number5",
+      "Key 6": "Number6",
+      "Key 7": "Number7",
+      "Key 8": "Number8",
+      "Key 9": "Number9",
+      "Key 0": "Number0",
+      "Key Plus": "Equals",
+      "Key Minus": "Minus",
+      "Key Pound": "Insert",
+      "Key Clear/Home": "Delete",
+      "Key Insert/Delete": "Backspace",
+      "Key Control": "Tab",
+      "Key Q": "Q",
+      "Key W": "W",
+      "Key E": "E",
+      "Key R": "R",
+      "Key T": "T",
+      "Key Y": "Y",
+      "Key U": "U",
+      "Key I": "I",
+      "Key O": "O",
+      "Key P": "P",
+      "Key At": "LeftBracket",
+      "Key Asterisk": "RightBracket",
+      "Key Up Arrow": "Backslash",
+      "Key Run/Stop": "CapsLock",
+      "Key A": "A",
+      "Key S": "S",
+      "Key D": "D",
+      "Key F": "F",
+      "Key G": "G",
+      "Key H": "H",
+      "Key J": "J",
+      "Key K": "K",
+      "Key L": "L",
+      "Key Colon": "Semicolon",
+      "Key Semicolon": "Apostrophe",
+      "Key Equal": "RightCtrl",
+      "Key Return": "Enter",
+      "Key Commodore": "LeftCtrl",
+      "Key Left Shift": "LeftShift",
+      "Key Z": "Z",
+      "Key X": "X",
+      "Key C": "C",
+      "Key V": "V",
+      "Key B": "B",
+      "Key N": "N",
+      "Key M": "M",
+      "Key Comma": "Comma",
+      "Key Period": "Period",
+      "Key Slash": "Slash",
+      "Key Right Shift": "RightShift",
+      "Key Cursor Up/Down": "Down",
+      "Key Cursor Left/Right": "Right",
+      "Key Space": "Space"
+    },
+    "ZXSpectrum Controller": {
+      "P1 Up": "Keypad8, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Keypad2, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Keypad4, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Keypad6, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Button": "Keypad1, J1 B1, X1 X",
+      "Key 1": "Number1",
+      "Key 2": "Number2",
+      "Key 3": "Number3",
+      "Key 4": "Number4",
+      "Key 5": "Number5",
+      "Key 6": "Number6",
+      "Key 7": "Number7",
+      "Key 8": "Number8",
+      "Key 9": "Number9",
+      "Key 0": "Number0",
+      "Key Break": "Delete",
+      "Key Delete": "Backspace",
+      "Key Q": "Q",
+      "Key W": "W",
+      "Key E": "E",
+      "Key R": "R",
+      "Key T": "T",
+      "Key Y": "Y",
+      "Key U": "U",
+      "Key I": "I",
+      "Key O": "O",
+      "Key P": "P",
+      "Key A": "A",
+      "Key S": "S",
+      "Key D": "D",
+      "Key F": "F",
+      "Key G": "G",
+      "Key H": "H",
+      "Key J": "J",
+      "Key K": "K",
+      "Key L": "L",
+      "Key Return": "Enter",
+      "Key Caps Shift": "LeftShift, RightShift",
+      "Key Z": "Z",
+      "Key X": "X",
+      "Key C": "C",
+      "Key V": "V",
+      "Key B": "B",
+      "Key N": "N",
+      "Key M": "M",
+      "Key Period": "Period",
+      "Key Symbol Shift": "LeftCtrl, RightCtrl",
+      "Key Semi-Colon": "Semicolon",
+      "Key Left Cursor": "Left",
+      "Key Right Cursor": "Right",
+      "Key Space": "Space",
+      "Key Up Cursor": "Up",
+      "Key Down Cursor": "Down",
+      "Key Comma": "Comma",
+      "Play Tape": "F1",
+      "Stop Tape": "F2",
+      "RTZ Tape": "F3",
+      "Key Quote": "Shift+Number2",
+      "Insert Next Tape": "F6",
+      "Insert Previous Tape": "F5",
+      "Next Tape Block": "F8",
+      "Prev Tape Block": "F7",
+      "Get Tape Status": "F9",
+      "Insert Next Disk": "F11",
+      "Insert Previous Disk": "F10",
+      "Get Disk Status": "F12"
+    },
+    "Intellivision Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 L": "Z, J1 B1, X1 X",
+      "P1 R": "X, J1 B2, X1 A",
+      "P1 Key0": "Keypad0",
+      "P1 Key1": "Keypad1",
+      "P1 Key2": "Keypad2",
+      "P1 Key3": "Keypad3",
+      "P1 Key4": "Keypad4",
+      "P1 Key5": "Keypad5",
+      "P1 Key6": "Keypad6",
+      "P1 Key7": "Keypad7",
+      "P1 Key8": "Keypad9",
+      "P1 Key9": "Keypad9",
+      "P1 Enter": "KeypadEnter",
+      "P1 Clear": "KeypadDecimal"
+    },
+    "PC-FX Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 I": "C, J1 B1, X1 X",
+      "P1 II": "X, J1 B2, X1 A",
+      "P1 III": "Z, J1 B4, X1 Y",
+      "P1 IV": "D, J1 B3, X1 B",
+      "P1 V": "S, J1 B11, X1 X",
+      "P1 VI": "A, J1 B12, X1 X",
+      "P1 Select": "Space, J1 B9, X1 Back",
+      "P1 Run": "Enter, J1 B10, X1 Start",
+      "P2 Mouse Left": "WMouse L",
+      "P2 Mouse Right": "WMouse R"
+    },
+    "Saturn Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Start": "Enter, J1 B10, X1 Start",
+      "P1 X": "D, J1 B3, X1 B",
+      "P1 Y": "S, J1 B11, X1 X",
+      "P1 Z": "A, J1 B12, X1 X",
+      "P1 A": "C, J1 B1, X1 X",
+      "P1 B": "X, J1 B2, X1 A",
+      "P1 C": "Z, J1 B4, X1 Y",
+      "P1 L": "Q, J1 B5, X1 LeftShoulder",
+      "P1 R": "W, J1 B6, X1 RightShoulder",
+      "P1 Mouse Left": "WMouse L",
+      "P1 Mouse Center": "WMouse M",
+      "P1 Mouse Right": "WMouse R",
+      "P1 Escape": "Escape",
+      "P1 F1": "F1",
+      "P1 F2": "F2",
+      "P1 F3": "F3",
+      "P1 F4": "F4",
+      "P1 F5": "F5",
+      "P1 F6": "F6",
+      "P1 F7": "F7",
+      "P1 F8": "F8",
+      "P1 F9": "F9",
+      "P1 F10": "F10",
+      "P1 F11": "F11",
+      "P1 F12": "F12",
+      "P1 Grave`": "Backtick",
+      "P1 1(One)": "Number1",
+      "P1 2": "Number2",
+      "P1 3": "Number3",
+      "P1 4": "Number4",
+      "P1 5": "Number5",
+      "P1 6": "Number6",
+      "P1 7": "Number7",
+      "P1 8": "Number8",
+      "P1 9": "Number9",
+      "P1 0(Zero)": "Number0",
+      "P1 Minus-": "Minus",
+      "P1 Equals=": "Equals",
+      "P1 Backslash\\": "Backslash",
+      "P1 Backspace": "Backspace",
+      "P1 Tab": "Tab",
+      "P1 Q": "Q",
+      "P1 W": "W",
+      "P1 E": "E",
+      "P1 R(Key)": "R",
+      "P1 T": "T",
+      "P1 Y(Key)": "Y",
+      "P1 U": "U",
+      "P1 I": "I",
+      "P1 O": "O",
+      "P1 P": "P",
+      "P1 LeftBracket[": "LeftBracket",
+      "P1 RightBracket]": "RightBracket",
+      "P1 Enter": "Enter",
+      "P1 CapsLock": "CapsLock",
+      "P1 A(Key)": "A",
+      "P1 S": "S",
+      "P1 D": "D",
+      "P1 F": "F",
+      "P1 G": "G",
+      "P1 H": "H",
+      "P1 J": "J",
+      "P1 K": "K",
+      "P1 L(Key)": "L",
+      "P1 Semicolon;": "Semicolon",
+      "P1 Quote'": "Apostrophe",
+      "P1 LeftShift": "LeftShift",
+      "P1 Z(Key)": "Z",
+      "P1 X(Key)": "X",
+      "P1 C(Key)": "C",
+      "P1 V": "V",
+      "P1 B(Key)": "B",
+      "P1 N": "N",
+      "P1 M": "M",
+      "P1 Comma,": "Comma",
+      "P1 Period.": "Period",
+      "P1 Slash/": "Slash",
+      "P1 RightShift": "RightShift",
+      "P1 LeftCtrl": "LeftCtrl",
+      "P1 LeftAlt": "LeftAlt",
+      "P1 Space": "Space",
+      "P1 RightAlt": "RightAlt",
+      "P1 RightCtrl": "RightCtrl",
+      "P1 ScrollLock": "ScrollLock",
+      "P1 Pause": "Pause",
+      "P1 Insert": "Insert",
+      "P1 Delete": "Delete",
+      "P1 Home": "Home",
+      "P1 End": "End",
+      "P1 PageUp": "PageUp",
+      "P1 PageDown": "PageDown",
+      "P1 CursorLeft": "Left",
+      "P1 NumLock": "NumLock",
+      "P1 KeypadSlash(Divide)": "KeypadDivide",
+      "P1 KeypadAsterisk(Multiply)": "KeypadMultiply",
+      "P1 KeypadMinus": "KeypadSubtract",
+      "P1 KeypadHome/7": "Keypad7",
+      "P1 KeypadUp/8": "Keypad8",
+      "P1 KeypadPageup/9": "Keypad9",
+      "P1 KeypadPlus": "KeypadAdd",
+      "P1 KeypadLeft/4": "Keypad4",
+      "P1 KeypadCenter/5": "Keypad5",
+      "P1 KeypadRight/6": "Keypad6",
+      "P1 KeypadEnd/1": "Keypad1",
+      "P1 KeypadDown/2": "Keypad2",
+      "P1 KeypadPagedown/3": "Keypad3",
+      "P1 KeypadEnter": "KeypadEnter",
+      "P1 KeypadInsert/0": "Keypad0",
+      "P1 KeypadDelete": "KeypadDecimal"
+    },
+    "PC Engine Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 B1": "C, J1 B3, X1 B",
+      "P1 B2": "X, J1 B2, X1 A",
+      "P1 I": "C, J1 B3, X1 B",
+      "P1 II": "X, J1 B2, X1 A",
+      "P1 III": "Z",
+      "P1 IV": "D",
+      "P1 V": "S",
+      "P1 VI": "A",
+      "P1 Select": "V, J1 B9, X1 Back",
+      "P1 Run": "Enter, J1 B10, X1 Start",
+      "P1 Mode: Set 2-button": "LeftBracket",
+      "P1 Mode: Set 6-button": "RightBracket"
+    },
+    "ColecoVision Basic Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 L": "Z, J1 B5, X1 LeftShoulder",
+      "P1 R": "X, J1 B6, X1 RightShoulder",
+      "P1 Key 1": "Keypad1, J1 B1, X1 X",
+      "P1 Key 2": "Keypad2, J1 B2, X1 A",
+      "P1 Key 3": "Keypad3, J1 B3, X1 B",
+      "P1 Key 4": "Keypad4, J1 B4, X1 Y",
+      "P1 Key 5": "Keypad5, J1 RotationZ-, X1 RStickUp",
+      "P1 Key 6": "Keypad6, J1 RotationZ+, X1 RStickDown",
+      "P1 Key 7": "Keypad7, J1 Z-, X1 RStickLeft",
+      "P1 Key 8": "Keypad8, J1 Z+, X1 RStickRight",
+      "P1 Key 9": "Keypad9, J1 B11, X1 LeftThumb",
+      "P1 Star": "KeypadEnter, J1 B9, X1 Back",
+      "P1 Key 0": "Keypad0, J1 B12, X1 RightThumb",
+      "P1 Pound": "KeypadDecimal, J1 B10, X1 Start"
+    },
+    "SMS Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 B1": "Z, J1 B1, X1 X",
+      "P1 B2": "X, J1 B2, X1 A",
+      "Reset": "J1 B9, X1 Back",
+      "Pause": "J1 B10, X1 Start"
+    },
+    "SMS Paddle Controller": {
+      "P1 Left": "Left, J1 POV1L",
+      "P1 Right": "Right, J1 POV1R",
+      "P1 B1": "Z, J1 B1, X1 X",
+      "Reset": "J1 B9, X1 Back",
+      "Pause": "J1 B10, X1 Start"
+    },
+    "SMS Light Phaser Controller": {
+      "P1 Trigger": "Z, J1 B1, X1 X, WMouse L",
+      "Reset": "J1 B9, X1 Back",
+      "Pause": "J1 B10, X1 Start"
+    },
+    "SMS Sports Pad Controller": {
+      "P1 Up": "Up, J1 POV1U",
+      "P1 Down": "Down, J1 POV1D",
+      "P1 Left": "Left, J1 POV1L",
+      "P1 Right": "Right, J1 POV1R",
+      "P1 B1": "Z, J1 B1, X1 X",
+      "P1 B2": "X, J1 B2, X1 A",
+      "Reset": "J1 B9, X1 Back",
+      "Pause": "J1 B10, X1 Start"
+    },
+    "SMS Keyboard Controller": {
+      "Key 1": "Number1",
+      "Key 2": "Number2",
+      "Key 3": "Number3",
+      "Key 4": "Number4",
+      "Key 5": "Number5",
+      "Key 6": "Number6",
+      "Key 7": "Number7",
+      "Key 8": "Number8",
+      "Key 9": "Number9",
+      "Key 0": "Number0",
+      "Key Minus": "Minus",
+      "Key Caret": "Equals",
+      "Key Yen": "Backspace",
+      "Key Break": "Delete",
+      "Key Function": "Tab",
+      "Key Q": "Q",
+      "Key W": "W",
+      "Key E": "E",
+      "Key R": "R",
+      "Key T": "T",
+      "Key Y": "Y",
+      "Key U": "U",
+      "Key I": "I",
+      "Key O": "O",
+      "Key P": "P",
+      "Key At": "LeftBracket",
+      "Key Left Bracket": "RightBracket",
+      "Key Return": "Enter",
+      "Key Up Arrow": "Up",
+      "Key Control": "CapsLock",
+      "Key A": "A",
+      "Key S": "S",
+      "Key D": "D",
+      "Key F": "F",
+      "Key G": "G",
+      "Key H": "H",
+      "Key J": "J",
+      "Key K": "K",
+      "Key L": "L",
+      "Key Semicolon": "Semicolon",
+      "Key Colon": "Apostrophe",
+      "Key Right Bracket": "Backslash",
+      "Key Left Arrow": "Left",
+      "Key Right Arrow": "Right",
+      "Key Shift": "LeftShift",
+      "Key Z": "Z",
+      "Key X": "X",
+      "Key C": "C",
+      "Key V": "V",
+      "Key B": "B",
+      "Key N": "N",
+      "Key M": "M",
+      "Key Comma": "Comma",
+      "Key Period": "Period",
+      "Key Slash": "Slash",
+      "Key PI": "RightShift",
+      "Key Down Arrow": "Down",
+      "Key Graph": "PageUp",
+      "Key Kana": "PageDown",
+      "Key Space": "Space",
+      "Key Home/Clear": "Home",
+      "Key Insert/Delete": "Insert",
+      "P1 Up": "J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 B1": "J1 B1, X1 X",
+      "P1 B2": "J1 B2, X1 A",
+      "Reset": "J1 B9, X1 Back",
+      "Pause": "J1 B10, X1 Start"
+    },
+    "GG Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 B1": "Z, J1 B1, X1 X",
+      "P1 B2": "X, J1 B2, X1 A",
+      "Reset": "J1 B9, X1 Back",
+      "P1 Start": "Enter, J1 B10, X1 Start"
+    },
+    "Dual Gameboy Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Start": "Enter, J1 B10, X1 Start",
+      "P1 Select": "Space, J1 B9, X1 Space",
+      "P1 B": "Z, J1 B1, X1 X",
+      "P1 A": "X, J1 B2, X1 A",
+      "P2 Up": "Keypad8, J1 RotationZ-, X1 RStickUp",
+      "P2 Down": "Keypad2, J1 RotationZ+, X1 RStickDown",
+      "P2 Left": "Keypad4, J1 Z-, X1 RStickLeft",
+      "P2 Right": "Keypad6, J1 Z+, X1 RStickRight",
+      "P2 Start": "RightBracket, J1 B5, X1 LeftShoulder",
+      "P2 Select": "LeftBracket, J1 B6, X1 RightShoulder",
+      "P2 B": "C, J1 B4, X1 Y",
+      "P2 A": "V, J1 B3, X1 B"
+    },
+    "TI83 Controller": {
+      "0": "Keypad0",
+      "1": "Keypad1",
+      "2": "Keypad2",
+      "3": "Keypad3",
+      "4": "Keypad4",
+      "5": "Keypad5",
+      "6": "Keypad6",
+      "7": "Keypad7",
+      "8": "Keypad8",
+      "9": "Keypad9",
+      "DOT": "KeypadDecimal",
+      "ON": "Space",
+      "ENTER": "Enter, KeypadEnter",
+      "DOWN": "Down",
+      "UP": "Up",
+      "LEFT": "Left",
+      "RIGHT": "Right",
+      "PLUS": "KeypadAdd",
+      "MINUS": "KeypadSubtract",
+      "MULTIPLY": "KeypadMultiply",
+      "DIVIDE": "KeypadDivide",
+      "CLEAR": "Escape",
+      "EXP": "6",
+      "DASH": "Minus",
+      "PARACLOSE": "0",
+      "TAN": "T",
+      "VARS": "V",
+      "PARAOPEN": "9",
+      "COS": "C",
+      "PRGM": "R",
+      "STAT": "S",
+      "SIN": "Period",
+      "MATRIX": "LeftBracket",
+      "X": "X",
+      "STO": "Insert",
+      "LN": "L",
+      "LOG": "O",
+      "SQUARED": "2",
+      "NEG1": "1",
+      "MATH": "M",
+      "ALPHA": "A",
+      "GRAPH": "G",
+      "TRACE": "Home",
+      "ZOOM": "Z",
+      "WINDOW": "W",
+      "Y": "Y",
+      "SECOND": "Slash",
+      "MODE": "Backslash",
+      "DEL": "Delete",
+      "COMMA": "Comma"
+    },
+    "GPGX Genesis Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 A": "Z, J1 B1, X1 X",
+      "P1 B": "X, J1 B2, X1 A",
+      "P1 C": "C, J1 B4, X1 Y",
+      "P1 Start": "Enter, J1 B10, X1 Start",
+      "P1 X": "A, J1 B3, X1 B",
+      "P1 Y": "S, J1 B5, X1 LeftShoulder",
+      "P1 Z": "D, J1 B6, X1 RightShoulder",
+      "P1 Mode": "E, J1 B9, X1 Back",
+      "P2 Lightgun Trigger": "WMouse L",
+      "P2 Lightgun Start": "Keypad5",
+      "P2 Mouse Left": "WMouse L",
+      "P2 Mouse Center": "WMouse M",
+      "P2 Mouse Right": "WMouse R",
+      "P2 Mouse Start": "Keypad5"
+    },
+    "PicoDrive Genesis Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 A": "Z, J1 B1, X1 X",
+      "P1 B": "X, J1 B2, X1 A",
+      "P1 C": "C, J1 B4, X1 Y",
+      "P1 Start": "Enter, J1 B10, X1 Start",
+      "P1 X": "A, J1 B3, X1 B",
+      "P1 Y": "S, J1 B5, X1 LeftShoulder",
+      "P1 Z": "D, J1 B6, X1 RightShoulder",
+      "P1 Mode": "E, J1 B9, X1 Back"
+    },
+    "WonderSwan Controller": {
+      "P1 X1": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 X3": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 X4": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 X2": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Y1": "Keypad8, J1 RotationZ-, X1 RStickUp",
+      "P1 Y3": "Keypad2, J1 RotationZ+, X1 RStickDown",
+      "P1 Y4": "Keypad4, J1 Z-, X1 RStickLeft",
+      "P1 Y2": "Keypad6, J1 Z+, X1 RStickRight",
+      "P1 Start": "Enter, J1 B10, X1 Start",
+      "P1 B": "Z, J1 B1, X1 X",
+      "P1 A": "X, J1 B2, X1 A",
+      "P2 X3": "X, J1 B2, X1 A",
+      "P2 X4": "Z, J1 B1, X1 X",
+      "P2 Y1": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P2 Y3": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P2 Y4": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P2 Y2": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P2 Start": "Enter, J1 B10, X1 Start"
+    },
+    "PSX Front Panel": {
+      "P1 Up": "X1 DpadUp, Up",
+      "P1 Down": "X1 DpadDown, Down",
+      "P1 Left": "X1 DpadLeft, Left",
+      "P1 Right": "X1 DpadRight, Right",
+      "P1 Select": "X1 Back, Space",
+      "P1 Start": "X1 Start, Enter",
+      "P1 Square": "X1 X, A",
+      "P1 Triangle": "X1 Y, S",
+      "P1 Circle": "X1 B, X",
+      "P1 Cross": "X1 A, Z",
+      "P1 L1": "X1 LeftShoulder, Q",
+      "P1 R1": "X1 RightShoulder, W",
+      "P1 L2": "X1 LeftTrigger, E",
+      "P1 R2": "X1 RightTrigger, R",
+      "P1 L3": "X1 LeftThumb, T",
+      "P1 R3": "X1 RightThumb, Y",
+      "P1 MODE": "D"
+    },
+    "Lynx Controller": {
+      "Up": "Up",
+      "Down": "Down",
+      "Left": "Left",
+      "Right": "Right",
+      "A": "X",
+      "B": "Z",
+      "Option 1": "A",
+      "Option 2": "S",
+      "Pause": "Enter"
+    },
+    "Apple IIe Keyboard": {
+      "Delete": "Delete",
+      "Left": "Left",
+      "Tab": "Tab",
+      "Down": "Down",
+      "Up": "Up",
+      "Return": "Enter",
+      "Right": "Right",
+      "Space": "Space",
+      "'": "Apostrophe",
+      ",": "Comma",
+      "-": "Minus",
+      ".": "Period",
+      "/": "Slash",
+      "0": "Keypad0",
+      "1": "Keypad1",
+      "2": "Keypad2",
+      "3": "Keypad3",
+      "4": "Keypad4",
+      "5": "Keypad5",
+      "6": "Keypad6",
+      "7": "Keypad7",
+      "8": "Keypad8",
+      "9": "Keypad9",
+      ";": "Semicolon",
+      "=": "Equals",
+      "[": "LeftBracket",
+      "\\": "Backslash",
+      "]": "RightBracket",
+      "`": "Backtick",
+      "A": "A",
+      "B": "B",
+      "C": "C",
+      "D": "D",
+      "E": "E",
+      "F": "F",
+      "G": "G",
+      "H": "H",
+      "I": "I",
+      "J": "J",
+      "K": "K",
+      "L": "L",
+      "M": "M",
+      "N": "N",
+      "O": "O",
+      "P": "P",
+      "Q": "Q",
+      "R": "R",
+      "S": "S",
+      "T": "T",
+      "U": "U",
+      "V": "V",
+      "W": "W",
+      "X": "X",
+      "Y": "Y",
+      "Z": "Z",
+      "Control": "RightCtrl",
+      "Shift": "RightShift",
+      "Caps Lock": "CapsLock"
+    },
+    "VirtualBoy Controller": {
+      "L_Up": "Up, X1 DpadUp, X1 LStickUp",
+      "L_Down": "Down, X1 DpadDown, X1 LStickDown",
+      "L_Left": "Left, X1 DpadLeft, X1 LStickLeft",
+      "L_Right": "Right, X1 DpadRight, X1 LStickRight",
+      "R_Up": "Keypad8, X1 RStickUp",
+      "R_Down": "Keypad2, X1 RStickDown",
+      "R_Left": "Keypad4, X1 RStickLeft",
+      "R_Right": "Keypad6, X1 RStickRight",
+      "B": "Z, X1 X",
+      "A": "X, X1 A",
+      "R": "W, X1 LeftShoulder",
+      "L": "E, X1 RightShoulder",
+      "Select": "Space, X1 Back",
+      "Start": "Enter, X1 Start"
+    },
+    "NeoGeo Portable Controller": {
+      "P1 Up": "Up, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, X1 DpadRight, X1 LStickRight",
+      "P1 B": "Z, J1 B1, X1 X",
+      "P1 A": "X, J1 B2, X1 A",
+      "P1 Option": "Enter, J1 B10, X1 Start"
+    },
+    "Vectrex Digital Controller": {
+      "P1 Up": "Up, J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "Down, J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "Left, J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "Right, J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 Button 1": "Z, J1 B2, X1 A",
+      "P1 Button 2": "X, J1 B3, X1 B",
+      "P1 Button 3": "A, J1 B1, X1 X",
+      "P1 Button 4": "S, J1 B4, X1 Y"
+    },
+    "Vectrex Analog Controller": {
+      "P1 Button 1": "Z, J1 B2, X1 A",
+      "P1 Button 2": "X, J1 B3, X1 B",
+      "P1 Button 3": "A, J1 B1, X1 X",
+      "P1 Button 4": "S, J1 B4, X1 Y"
+    },
+    "O2 Joystick": {
+      "P1 Up": "Up",
+      "P1 Down": "Down",
+      "P1 Left": "Left",
+      "P1 Right": "Right",
+      "P1 F": "Z",
+      "0": "Keypad0",
+      "1": "Keypad1",
+      "2": "Keypad2",
+      "3": "Keypad3",
+      "4": "Keypad4",
+      "5": "Keypad5",
+      "6": "Keypad6",
+      "7": "Keypad7",
+      "8": "Keypad8",
+      "9": "Keypad9",
+      "YES": "Y",
+      "NO": "N",
+      "ENT": "KeypadEnter"
+    }
+  },
+  "AllTrollersAutoFire": {
+    "NES Controller": {
+      "P1 B": "A",
+      "P1 A": "S"
+    },
+    "Gameboy Controller": {
+      "B": "A",
+      "A": "S"
+    },
+    "Gameboy Controller H": {
+      "B": "A",
+      "A": "S"
+    },
+    "GBAController": {
+      "B": "A",
+      "A": "S"
+    },
+    "Atari 2600 Basic Controller": {
+      "P1 Button": "A",
+      "P2 Button": "S"
+    },
+    "Atari 7800 Basic Controller": {
+      "P1 Button": "A",
+      "P2 Button": "S"
+    },
+    "PC Engine Controller": {
+      "P1 B2": "A",
+      "P1 B1": "S"
+    },
+    "SMS Controller": {
+      "P1 B1": "A",
+      "P1 B2": "S"
+    },
+    "GPGX Genesis Controller": {},
+    "GBA Controller": {
+      "B": "A",
+      "A": "S"
+    },
+    "WonderSwan Controller": {
+      "P1 B": "A",
+      "P1 A": "S",
+      "P2 X4": "A",
+      "P2 X3": "S"
+    },
+    "Apple IIe Keyboard": {
+      "Return": "Enter"
+    }
+  },
+  "AllTrollersAnalog": {
+    "NES Controller": {
+      "P2 Paddle": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      },
+      "P2 Zapper X": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      },
+      "P2 Zapper Y": {
+        "Value": "WMouse Y",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      },
+      "P3 Paddle": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      },
+      "P3 Zapper X": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      },
+      "P3 Zapper Y": {
+        "Value": "WMouse Y",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      }
+    },
+    "Atari 7800 Paddle Controller": {
+      "P1 Paddle": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      }
+    },
+    "Atari 7800 Light Gun Controller": {
+      "P1 VPos": {
+        "Value": "WMouse Y",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      },
+      "P1 HPos": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      }
+    },
+    "NDS Controller": {
+      "Touch X": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      },
+      "Touch Y": {
+        "Value": "WMouse Y",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      }
+    },
+    "Nintendo 64 Controller": {
+      "P1 X Axis": {
+        "Value": "X1 LeftThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Y Axis": {
+        "Value": "X1 LeftThumbY Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P2 X Axis": {
+        "Value": "",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P2 Y Axis": {
+        "Value": "",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P3 X Axis": {
+        "Value": "",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P3 Y Axis": {
+        "Value": "",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P4 X Axis": {
+        "Value": "",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P4 Y Axis": {
+        "Value": "",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      }
+    },
+    "GPGX Genesis Controller": {
+      "P2 Lightgun X": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      },
+      "P2 Lightgun Y": {
+        "Value": "WMouse Y",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      },
+      "P2 Mouse X": {
+        "Value": "X1 LeftThumbX Axis",
+        "Mult": 0.1,
+        "Deadzone": 0.0
+      },
+      "P2 Mouse Y": {
+        "Value": "X1 LeftThumbY Axis",
+        "Mult": 0.1,
+        "Deadzone": 0.0
+      }
+    },
+    "WonderSwan Controller": {},
+    "Lynx Controller": {},
+    "PSX Front Panel": {
+      "P1 LStick X": {
+        "Value": "X1 LeftThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 LStick Y": {
+        "Value": "X1 LeftThumbY Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 RStick X": {
+        "Value": "X1 RightThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 RStick Y": {
+        "Value": "X1 RightThumbY Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      }
+    },
+    "Apple IIe Keyboard": {},
+    "LibRetro Controls": {
+      "Pointer X": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "Pointer Y": {
+        "Value": "WMouse Y",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Pointer X": {
+        "Value": "",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Pointer Y": {
+        "Value": "",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      }
+    },
+    "PC-FX Controller": {
+      "P2 Mouse X": {
+        "Value": "X1 LeftThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P2 Mouse Y": {
+        "Value": "X1 LeftThumbY Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      }
+    },
+    "SNES Controller": {
+      "P1 Mouse X": {
+        "Value": "X1 LeftThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Mouse Y": {
+        "Value": "X1 LeftThumbY Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P2 Scope X": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P2 Scope Y": {
+        "Value": "WMouse Y",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      }
+    },
+    "VirtualBoy Controller": {},
+    "NeoGeo Portable Controller": {},
+    "Saturn Controller": {
+      "P1 Right Stick Horizontal": {
+        "Value": "X1 RightThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Right Stick Vertical": {
+        "Value": "",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Right Throttle": {
+        "Value": "X1 RightThumbY Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Left Stick Horizontal": {
+        "Value": "X1 LeftThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Left Stick Vertical": {
+        "Value": "X1 LeftThumbY Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Left Throttle": {
+        "Value": "",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Wheel": {
+        "Value": "X1 LeftThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Stick Horizontal": {
+        "Value": "X1 LeftThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Stick Vertical": {
+        "Value": "X1 LeftThumbY Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Throttle": {
+        "Value": "X1 RightThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 X": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Y": {
+        "Value": "WMouse Y",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      }
+    },
+    "SMS Paddle Controller": {
+      "P1 Paddle": {
+        "Value": "X1 LeftThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      }
+    },
+    "SMS Light Phaser Controller": {
+      "P1 X": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      },
+      "P1 Y": {
+        "Value": "WMouse Y",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      }
+    },
+    "SMS Sports Pad Controller": {
+      "P1 X": {
+        "Value": "X1 LeftThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P1 Y": {
+        "Value": "X1 LeftThumbY Axis",
+        "Mult": -1.0,
+        "Deadzone": 0.1
+      },
+      "P2 X": {
+        "Value": "X2 LeftThumbX Axis",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      },
+      "P2 Y": {
+        "Value": "X2 LeftThumbY Axis",
+        "Mult": -1.0,
+        "Deadzone": 0.1
+      }
+    }
+  },
+  "AllTrollersFeedbacks": {
+    "Nintendo 64 Controller": {
+      "P1 Rumble Pak": {
+        "Channels": "Left+Right",
+        "GamepadPrefix": "X1 ",
+        "Prescale": 1.0
+      }
+    }
+  },
+  "GbAsSgb": false,
+  "LibretroCore": null,
+  "DontTryOtherCores": false,
+  "LastWrittenFrom": "2.8",
+  "LastWrittenFromDetailed": "GIT HEAD#01cd5c256",
+  "HostInputMethod": 1,
+  "UseStaticWindowTitles": false,
+  "ModifierKeys": [],
+  "MergeLAndRModifierKeys": true,
+  "OSDMessageDuration": 2
+}


### PR DESCRIPTION
Fixed stupid bug where if config.ini is missing from the emulator folder the wrong lua core is launched, despite us manually feeding it config files

This fixes the "missing socket.core" bug that happens when opening Bizhawk with our lua script within the app