### PR TITLE
Fixed bug abuse for Metroid.

### DIFF
--- a/Games/Retro_ML.Metroid/Neural/Scoring/ProgressScoreFactor.cs
+++ b/Games/Retro_ML.Metroid/Neural/Scoring/ProgressScoreFactor.cs
@@ -112,7 +112,7 @@ internal class ProgressScoreFactor : IScoreFactor
             {
                 var dirr = df.GetDirectionToNearestGoodTile();
                 navigationDirection[0, 0] = dirr[0, 0];
-                navigationDirection[0, 1] = dirr[0, 1];
+                navigationDirection[0, 1] = 0;
             }
         }
 


### PR DESCRIPTION
AI won't be rewared for going back and forth between the room edges of a powerup room